### PR TITLE
std::greater requires <functional>

### DIFF
--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <functional>
 #include <queue>
 
 #include "marisa/grimoire/algorithm.h"


### PR DESCRIPTION
I [came around](https://ci.appveyor.com/project/superbobry/marisa-trie/build/job/f5on1axoodnqku50) another compilation issue on Windows: VS 2012 does not re-export `std::greater` from `<algorithm>`. The fix is trivial :)