### PR TITLE
Fix Clang failing TestKey() test from bad pointer arithmetic.

### DIFF
--- a/lib/marisa/grimoire/trie/key.h
+++ b/lib/marisa/grimoire/trie/key.h
@@ -164,7 +164,8 @@ class ReverseKey {
   }
 
   const char *ptr() const {
-    return ptr_ - length_ + 1;
+    intptr_t p = reinterpret_cast<intptr_t>(ptr_) - length_ + 1;
+    return reinterpret_cast<const char*>(p);
   }
   std::size_t length() const {
     return length_;


### PR DESCRIPTION
Clang fails this test on `make check`:

```
trie-test.cc:71: TestKey(): 115: Assertion `r_key.ptr() == NULL' failed.
```

This patch uses `intptr_t` for pointer arithmetic to enable clang support.