### PR TITLE
Update Entry to use NULL to mean empty.

### DIFF
--- a/lib/marisa/grimoire/trie/entry.h
+++ b/lib/marisa/grimoire/trie/entry.h
@@ -9,8 +9,7 @@ namespace trie {
 
 class Entry {
  public:
-  Entry()
-      : ptr_(static_cast<const char *>(NULL) - 1), length_(0), id_(0) {}
+  Entry() : ptr_(NULL), length_(0), id_(0) {}
   Entry(const Entry &entry)
       : ptr_(entry.ptr_), length_(entry.length_), id_(entry.id_) {}
 
@@ -23,13 +22,13 @@ class Entry {
 
   char operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= length_, MARISA_BOUND_ERROR);
-    return *(ptr_ - i);
+    return *(ptr_ - i - 1);
   }
 
   void set_str(const char *ptr, std::size_t length) {
     MARISA_DEBUG_IF((ptr == NULL) && (length != 0), MARISA_NULL_ERROR);
     MARISA_DEBUG_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    ptr_ = ptr + length - 1;
+    ptr_ = ptr + length;
     length_ = (UInt32)length;
   }
   void set_id(std::size_t id) {
@@ -38,7 +37,7 @@ class Entry {
   }
 
   const char *ptr() const {
-    return ptr_ - length_ + 1;
+    return ptr_ - length_;
   }
   std::size_t length() const {
     return length_;


### PR DESCRIPTION
Fixes the following `make check` test failure when using clang:

  TestEntry(): 212: Assertion `entry.ptr() == NULL' failed.

This is essentially the same fix as was used to fix ReverseKey in
s-yata/marisa-trie@cbab26f0.