### PR TITLE
Update marisa-benchmark.cc

### DIFF
--- a/tools/marisa-benchmark.cc
+++ b/tools/marisa-benchmark.cc
@@ -45,7 +45,7 @@ void print_help(const char *cmd) {
       << "] (default: 1)\n"
       "  -n, --max-num-tries=[N]  limit the number of tries"
       " [" << MARISA_MIN_NUM_TRIES << ", " << MARISA_MAX_NUM_TRIES
-      << "] (default: 10)\n"
+      << "] (default: 5)\n"
       "  -t, --text-tail      build a dictionary with text TAIL (default)\n"
       "  -b, --binary-tail    build a dictionary with binary TAIL\n"
       "  -w, --weight-order   arrange siblings in weight order (default)\n"


### PR DESCRIPTION
Fixed `print_help` to display accurate default values.

`$ marisa-benchmark --help` displays
```
Options:
  ...
  -n, --max-num-tries=[N]  limit the number of tries [1, 127] (default: 10)
  ...
```
but  `int param_max_num_tries = 5;`

so I just fixed the string. Nothing big!