### PR TITLE
Fix `swap` overload

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -162,6 +162,13 @@ typedef enum marisa_config_mask_ {
 #endif  // __cplusplus
 
 #ifdef __cplusplus
+
+// `std::swap` is in <utility> since C++ 11 but in <algorithm> in C++ 98:
+#if __cplusplus>=201103L
+#include <utility>
+#else
+#include <algorithm>
+#endif
 namespace marisa {
 
 typedef ::marisa_uint8  UInt8;
@@ -175,12 +182,7 @@ typedef ::marisa_cache_level CacheLevel;
 typedef ::marisa_tail_mode TailMode;
 typedef ::marisa_node_order NodeOrder;
 
-template <typename T>
-inline void swap(T &lhs, T &rhs) {
-  T temp = lhs;
-  lhs = rhs;
-  rhs = temp;
-}
+using std::swap;
 
 }  // namespace marisa
 #endif  // __cplusplus


### PR DESCRIPTION
Use `std::swap` instead of a custom version to avoid "ambiguous call"
errors.

Previously, this code failed to compile:

    std::unique_ptr<marisa::Trie> a;

    // Here, unique_ptr calls `swap` internally using ADL.
    // Previously, this failed to compile:
    a.reset(new marisa::Trie());

There was a PR previously attempting to fix it but it didn't have a C++ 98 fallback and got closed by its author: https://github.com/s-yata/marisa-trie/pull/17