### PR TITLE
remove extra semicolon

### DIFF
--- a/lib/marisa/grimoire/algorithm/sort.h
+++ b/lib/marisa/grimoire/algorithm/sort.h
@@ -187,7 +187,7 @@ template <typename Iterator>
 std::size_t sort(Iterator begin, Iterator end) {
   MARISA_DEBUG_IF(begin > end, MARISA_BOUND_ERROR);
   return details::sort(begin, end, 0);
-};
+}
 
 }  // namespace algorithm
 }  // namespace grimoire


### PR DESCRIPTION
GCC prints warning about that when Marisa is build with pedantic warnings.

Btw, thanks from that useful library ;-)