### PR TITLE
BitVector::build_index: 100x speedup

### DIFF
--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -805,7 +805,11 @@ void BitVector::build_index(const BitVector &bv,
 
       const std::size_t zero_bit_id = -num_0s % 512;
       if (unit_num_0s > zero_bit_id) {
-        select0s_.push_back(select_bit(zero_bit_id, bit_id, ~unit));
+        // select0s_ is UInt32, but select_bit returns size_t, so cast to
+        // suppress narrowing conversion warning.  push_back checks the
+        // size, so there is no truncation here.
+        select0s_.push_back(
+            static_cast<UInt32>(select_bit(zero_bit_id, bit_id, ~unit)));
       }
 
       num_0s += unit_num_0s;
@@ -814,7 +818,8 @@ void BitVector::build_index(const BitVector &bv,
     if (enables_select1) {
       const std::size_t one_bit_id = -num_1s % 512;
       if (unit_num_1s > one_bit_id) {
-        select1s_.push_back(select_bit(one_bit_id, bit_id, unit));
+        select1s_.push_back(
+            static_cast<UInt32>(select_bit(one_bit_id, bit_id, unit)));
       }
     }
 

--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -369,6 +369,14 @@ std::size_t select_bit(std::size_t i, std::size_t bit_id,
   return bit_id + SELECT_TABLE[i][unit & 0xFF];
 }
   #endif  // MARISA_USE_SSE2
+
+
+// This is only used by build_index, so don't worry about the small performance
+// penalty from not having version taking only a UInt32.
+inline std::size_t select_bit(std::size_t i, std::size_t bit_id, UInt32 unit) {
+  return select_bit(i, bit_id, /*unit_lo=*/unit, /*unit_hi=*/0);
+}
+
  #endif  // MARISA_WORD_SIZE == 64
 #endif  // MARISA_USE_BMI2
 

--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "marisa/grimoire/vector/pop-count.h"
 #include "marisa/grimoire/vector/bit-vector.h"
 


### PR DESCRIPTION
Process the `BitVector` unit-by-unit instead of bit-by-bit.

Use `PopCount::count()` to update `num_1s` and use `select_bit` to find
the bit positions for the `select0s_` and `select1s_` indexes.

According to my benchmarks, the old bit-by-bit version processed a
256kbit vector at about 20MB/s independent of `enables_select0` and
`enables_select1`.

The new version is 50x-150x faster, depending on the compiler and build_index
options.

`enables_select_0=enables_select1=false`:
popcnt, no bmi2: 1600MB/s
popcnt, no bmi2: 2500MB/s
popcnt and bmi2: 2900MB/s

`enables_select_0=enables_select1=true`:
no popcnt, no bmi2: 1100MB/s
popcnt, no bmi2: 1600MB/s
popcnt and bmi2: 1800MB/s