### PR TITLE
Use MARISA_DEBUG_IF in scoped-*.h as opposed to MARISA_THROW_IF

### DIFF
--- a/include/marisa/scoped-array.h
+++ b/include/marisa/scoped-array.h
@@ -16,7 +16,7 @@ class scoped_array {
   }
 
   void reset(T *array = NULL) {
-    MARISA_THROW_IF((array != NULL) && (array == array_), MARISA_RESET_ERROR);
+    MARISA_DEBUG_IF((array != NULL) && (array == array_), MARISA_RESET_ERROR);
     scoped_array(array).swap(*this);
   }
 

--- a/include/marisa/scoped-ptr.h
+++ b/include/marisa/scoped-ptr.h
@@ -16,7 +16,7 @@ class scoped_ptr {
   }
 
   void reset(T *ptr = NULL) {
-    MARISA_THROW_IF((ptr != NULL) && (ptr == ptr_), MARISA_RESET_ERROR);
+    MARISA_DEBUG_IF((ptr != NULL) && (ptr == ptr_), MARISA_RESET_ERROR);
     scoped_ptr(ptr).swap(*this);
   }
 


### PR DESCRIPTION
Hi folks

With this change, developers can take the marisa library without being forced to enable exceptions for their whole library / application by using "-fexceptions". However, some projects decide to [not to enable exceptions](https://google.github.io/styleguide/cppguide.html#Exceptions). 

The reason that we have to enable exceptions for the whole application/library is that the marisa library throws exceptions in header files. If we don't enable exceptions, there will be two implementations of those functions that throw. This violates the [ODR](https://en.wikipedia.org/wiki/One_Definition_Rule).

There are only two places where we throw exceptions from header files in non-debug mode.
IMO, it might be reasonable to use MARISA_DEBUG_IF there instead of MARISA_THROW_IF.

Also, I think the new behavior is also closer to unique_ptr::reset.
From cppreference:
> A test for self-reset, i.e. whether ptr points to an object already managed by *this, is not performed, except where provided as a compiler extension or as a debugging assert.  

MARISA_DEBUG_IF is like the debugging assert that it mentions.

What do you think?

Thanks!