### PR TITLE
Fix format security

### DIFF
--- a/bindings/ruby/marisa-swig_wrap.cxx
+++ b/bindings/ruby/marisa-swig_wrap.cxx
@@ -1402,7 +1402,7 @@ SWIG_Ruby_AppendOutput(VALUE target, VALUE o) {
 /* Error manipulation */
 
 #define SWIG_ErrorType(code)                            SWIG_Ruby_ErrorType(code)               
-#define SWIG_Error(code, msg)            		rb_raise(SWIG_Ruby_ErrorType(code), msg)
+#define SWIG_Error(code, msg)            		rb_raise(SWIG_Ruby_ErrorType(code), "%s", msg)
 #define SWIG_fail                        		goto fail				 
 
 


### PR DESCRIPTION
Prevent gcc errors when using `-Werror=format-security`.