### PR TITLE
Optimize select_bit

### DIFF
--- a/lib/marisa/grimoire/intrin.h
+++ b/lib/marisa/grimoire/intrin.h
@@ -135,4 +135,9 @@
  #endif  // MARISA_WORD_SIZE == 64
 #endif  // _MSC_VER
 
+#if defined(__aarch64__)
+ #define MARISA_AARCH64
+ #include <arm_neon.h>
+#endif
+
 #endif  // MARISA_GRIMOIRE_INTRIN_H_

--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -196,11 +196,16 @@ std::size_t select_bit(std::size_t i, std::size_t bit_id, UInt64 unit) {
 
     counts = static_cast<UInt64>(_mm_cvtsi128_si64(
        _mm_add_epi8(lower_counts, upper_counts)));
-  #else  // defined(MARISA_X64) && defined(MARISA_USE_SSSE3)
+  #elif defined(MARISA_AARCH64)
+    // Byte-wise popcount using CNT (plus a lot of conversion noise).
+    // This actually only requires NEON, not AArch64, but we are already
+    // in a 64-bit `#ifdef`.
+    counts = vget_lane_u64(vreinterpret_u64_u8(vcnt_u8(vcreate_u8(unit))), 0);
+  #else  // defined(MARISA_AARCH64)
     counts = unit - ((unit >> 1) & MASK_55);
     counts = (counts & MASK_33) + ((counts >> 2) & MASK_33);
     counts = (counts + (counts >> 4)) & MASK_0F;
-  #endif  // defined(MARISA_X64) && defined(MARISA_USE_SSSE3)
+  #endif  // defined(MARISA_AARCH64)
     counts *= MASK_01;
   }
 

--- a/lib/marisa/grimoire/vector/pop-count.h
+++ b/lib/marisa/grimoire/vector/pop-count.h
@@ -51,9 +51,12 @@ class PopCount {
  #else  // _MSC_VER
     return static_cast<std::size_t>(_mm_popcnt_u64(x));
  #endif  // _MSC_VER
-#else  // defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
+#elif defined(MARISA_AARCH64)
+    // Byte-wise popcount followed by horizontal add.
+    return vaddv_u8(vcnt_u8(vcreate_u8(x)));
+#else  // defined(MARISA_AARCH64)
     return PopCount(x).lo64();
-#endif  // defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
+#endif  // defined(MARISA_AARCH64)
   }
 
  private:


### PR DESCRIPTION
1. AArch64 byte-wise popcount optimization

ARM NEON has a byte-wise popcount instruction, which helps to optimize
`select_bit` and `PopCount::count`.  Use it for AArch64 (64-bit ARM).

15% speedup for `Rank1`, 4% for `Select0` and 3% for `Select1`.
(60% for `PopCount::count` itself.)

2. byte-serial 32-bit version

This gives a 9% speedup on `select0` and 7% on `select1`.
(Tested on Pixel 3 in armeabi-v7a mode.)

This is likely because the branches of this unrolled linear
search are more predictable than the binary search that was
used previously.

3. Use lookup table

Instead of computing `(counts | MASK_80) - ((i + 1) * MASK_01)`,
we pre-compute a lookup table
```
PREFIX_SUM_OVERFLOW[i] = (0x80 - (i + 1)) * MASK_01 = (0x7F - i) * MASK_01
```
then use `counts + PREFIX_SUM_OVERFLOW[i]`.

This uses a `UInt64[64]` or 0.5kiB lookup table. The trick is from:
Gog, Simon and Matthias Petri. “Optimized succinct data structures for
massive data.” Software: Practice and Experience 44 (2014): 1287 - 1314.

https://www.semanticscholar.org/paper/Optimized-succinct-data-structures-for-massive-data-Gog-Petri/c7e7f02f441ebcc0aeffdcad2964185926551ec3

This gives a 2-3% speedup for `BitVector::select0`/`select1`.