### PR TITLE
Add wordsize detection for LoongArch64.

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -31,7 +31,7 @@ typedef uint64_t marisa_uint64;
 #if defined(_WIN64) || defined(__amd64__) || defined(__x86_64__) || \
     defined(__ia64__) || defined(__ppc64__) || defined(__powerpc64__) || \
     defined(__sparc64__) || defined(__mips64__) || defined(__aarch64__) || \
-    defined(__s390x__)
+    defined(__s390x__) || defined(__loongarch64)
  #define MARISA_WORD_SIZE 64
 #else  // defined(_WIN64), etc.
  #define MARISA_WORD_SIZE 32


### PR DESCRIPTION
Compiling the marisa failed for loongarch64 in my local system.
```
$ git clone https://github.com/s-yata/marisa-trie.git
$ cd marisa-trie
$ autoreconf -i
$ ./configure
$ make
$ make check
```
The results of make check are as follows,
```
make[3]: Entering directory '/home/zdd/marisa-trie/tests'
FAIL: base-test
PASS: io-test
PASS: vector-test
PASS: trie-test
PASS: marisa-test
============================
Testsuite summary for marisa 0.2.6
============================
# TOTAL: 5
# PASS:  4
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
```
I have added wordsize detection for LoongArch64, please review.
I have also submitted a bug request to Debian BTS, the BugID can be found at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1065467
BTW, the documentations of the LoongArch architecture can be found at the following links,
ISA: https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI: https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html

thanks,
Dandan Zhang
