### PR TITLE
Fix detection of MARISA_WORD_SIZE

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -28,14 +28,13 @@ typedef uint32_t marisa_uint32;
 typedef uint64_t marisa_uint64;
 #endif  // _MSC_VER
 
-#if defined(_WIN64) || defined(__amd64__) || defined(__x86_64__) || \
-    defined(__ia64__) || defined(__ppc64__) || defined(__powerpc64__) || \
-    defined(__sparc64__) || defined(__mips64__) || defined(__aarch64__) || \
-    defined(__s390x__)
+#if (UINTPTR_MAX == 0xffffffffffffffff)
  #define MARISA_WORD_SIZE 64
-#else  // defined(_WIN64), etc.
+#elif (UINTPTR_MAX == 0xffffffff)
  #define MARISA_WORD_SIZE 32
-#endif  // defined(_WIN64), etc.
+#else
+ #error Failed to detect MARISA_WORD_SIZE
+#endif
 
 //#define MARISA_WORD_SIZE  (sizeof(void *) * 8)
 


### PR DESCRIPTION
Detect the MARISA_WORD_SIZE independent of architecture.

Fixes: https://github.com/s-yata/marisa-trie/issues/40
Fixes: https://github.com/s-yata/marisa-trie/issues/57
Fixes: https://github.com/s-yata/marisa-trie/pull/44
Fixes: https://github.com/s-yata/marisa-trie/pull/46
Fixes: https://github.com/s-yata/marisa-trie/pull/56