### PR TITLE
Use default copy constructor and copy-assignment

### DIFF
--- a/include/marisa/key.h
+++ b/include/marisa/key.h
@@ -14,15 +14,9 @@ class Key {
   Key() : ptr_(NULL), length_(0), union_() {
     union_.id = 0;
   }
-  Key(const Key &key)
-      : ptr_(key.ptr_), length_(key.length_), union_(key.union_) {}
 
-  Key &operator=(const Key &key) {
-    ptr_ = key.ptr_;
-    length_ = key.length_;
-    union_ = key.union_;
-    return *this;
-  }
+  Key(const Key &key) = default;
+  Key &operator=(const Key &key) = default;
 
   char operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= length_, MARISA_BOUND_ERROR);

--- a/lib/marisa/grimoire/trie/cache.h
+++ b/lib/marisa/grimoire/trie/cache.h
@@ -14,15 +14,9 @@ class Cache {
   Cache() : parent_(0), child_(0), union_() {
     union_.weight = FLT_MIN;
   }
-  Cache(const Cache &cache)
-      : parent_(cache.parent_), child_(cache.child_), union_(cache.union_) {}
 
-  Cache &operator=(const Cache &cache) {
-    parent_ = cache.parent_;
-    child_ = cache.child_;
-    union_ = cache.union_;
-    return *this;
-  }
+  Cache(const Cache &cache) = default;
+  Cache &operator=(const Cache &cache) = default;
 
   void set_parent(std::size_t parent) {
     MARISA_DEBUG_IF(parent > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);

--- a/lib/marisa/grimoire/trie/entry.h
+++ b/lib/marisa/grimoire/trie/entry.h
@@ -10,15 +10,9 @@ namespace trie {
 class Entry {
  public:
   Entry() : ptr_(NULL), length_(0), id_(0) {}
-  Entry(const Entry &entry)
-      : ptr_(entry.ptr_), length_(entry.length_), id_(entry.id_) {}
 
-  Entry &operator=(const Entry &entry) {
-    ptr_ = entry.ptr_;
-    length_ = entry.length_;
-    id_ = entry.id_;
-    return *this;
-  }
+  Entry(const Entry &entry) = default;
+  Entry &operator=(const Entry &entry) = default;
 
   char operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= length_, MARISA_BOUND_ERROR);

--- a/lib/marisa/grimoire/trie/key.h
+++ b/lib/marisa/grimoire/trie/key.h
@@ -12,17 +12,9 @@ class Key {
   Key() : ptr_(NULL), length_(0), union_(), id_(0) {
     union_.terminal = 0;
   }
-  Key(const Key &entry)
-      : ptr_(entry.ptr_), length_(entry.length_),
-        union_(entry.union_), id_(entry.id_) {}
 
-  Key &operator=(const Key &entry) {
-    ptr_ = entry.ptr_;
-    length_ = entry.length_;
-    union_ = entry.union_;
-    id_ = entry.id_;
-    return *this;
-  }
+  Key(const Key &entry) = default;
+  Key &operator=(const Key &entry) = default;
 
   char operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= length_, MARISA_BOUND_ERROR);
@@ -118,17 +110,9 @@ class ReverseKey {
   ReverseKey() : ptr_(NULL), length_(0), union_(), id_(0) {
     union_.terminal = 0;
   }
-  ReverseKey(const ReverseKey &entry)
-      : ptr_(entry.ptr_), length_(entry.length_),
-        union_(entry.union_), id_(entry.id_) {}
 
-  ReverseKey &operator=(const ReverseKey &entry) {
-    ptr_ = entry.ptr_;
-    length_ = entry.length_;
-    union_ = entry.union_;
-    id_ = entry.id_;
-    return *this;
-  }
+  ReverseKey(const ReverseKey &entry) = default;
+  ReverseKey &operator=(const ReverseKey &entry) = default;
 
   char operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= length_, MARISA_BOUND_ERROR);

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -256,19 +256,18 @@ void LoudsTrie::build_(Keyset &keyset, const Config &config) {
   Vector<UInt32> terminals;
   build_trie(keys, &terminals, config, 1);
 
-  typedef std::pair<UInt32, UInt32> TerminalIdPair;
-
-  Vector<TerminalIdPair> pairs;
-  pairs.resize(terminals.size());
-  for (std::size_t i = 0; i < pairs.size(); ++i) {
+  using TerminalIdPair = std::pair<UInt32, UInt32>;
+  const std::size_t pairs_size = terminals.size();
+  std::unique_ptr<TerminalIdPair[]> pairs(new TerminalIdPair[pairs_size]);
+  for (std::size_t i = 0; i < pairs_size; ++i) {
     pairs[i].first = terminals[i];
     pairs[i].second = (UInt32)i;
   }
   terminals.clear();
-  std::sort(pairs.begin(), pairs.end());
+  std::sort(pairs.get(), pairs.get() + pairs_size);
 
   std::size_t node_id = 0;
-  for (std::size_t i = 0; i < pairs.size(); ++i) {
+  for (std::size_t i = 0; i < pairs_size; ++i) {
     while (node_id < pairs[i].first) {
       terminal_flags_.push_back(false);
       ++node_id;


### PR DESCRIPTION
`std::memcpy` in `Vector::realloc` raises a warning if we remove the cast to `void *` and the type has a non trivial copy-assignment operator, for example:

```
lib/marisa/grimoire/vector/vector.h:272:18: warning: 'void* memcpy(void*, const void*, size_t)'
writing to an object of type 'class marisa::grimoire::trie::Key' with no trivial copy-assignment;
use copy-assignment or copy-initialization instead [-Wclass-memaccess]
  272 |       std::memcpy(new_objs, static_cast<const void *>(src),
      |       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  273 |                   sizeof(T) * src_size);
```

This is easily fixable by defaulting the copy assignment operator for such types, which is also less code and is less error-prone.

After defaulting the operators, the one remaining warning case was `TerminalIdPair`. The fix there was to not use a vector, as it was in a fixed size container anyway.