### PR TITLE
Enable Trie::mmap() to use MAP_POPULATE

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -87,6 +87,13 @@ typedef enum marisa_error_code_ {
   MARISA_FORMAT_ERROR = 10,
 } marisa_error_code;
 
+// Flags for memory mapping are defined as members of marisa_map_flags.
+// Trie::open() accepts a combination of these flags.
+typedef enum marisa_map_flags {
+  // MARISA_MAP_POPULATE specifies MAP_POPULATE.
+  MARISA_MAP_POPULATE = 1 << 0,
+} marisa_map_flags;
+
 // Min/max values, flags and masks for dictionary settings are defined below.
 // Please note that unspecified settings will be replaced with the default
 // settings. For example, 0 is equivalent to (MARISA_DEFAULT_NUM_TRIES |

--- a/include/marisa/trie.h
+++ b/include/marisa/trie.h
@@ -24,7 +24,7 @@ class Trie {
 
   void build(Keyset &keyset, int config_flags = 0);
 
-  void mmap(const char *filename);
+  void mmap(const char *filename, int flags = 0);
   void map(const void *ptr, std::size_t size);
 
   void load(const char *filename);

--- a/lib/marisa/grimoire/io/mapper.h
+++ b/lib/marisa/grimoire/io/mapper.h
@@ -14,7 +14,7 @@ class Mapper {
   Mapper();
   ~Mapper();
 
-  void open(const char *filename);
+  void open(const char *filename, int flags = 0);
   void open(const void *ptr, std::size_t size);
 
   template <typename T>
@@ -50,7 +50,7 @@ class Mapper {
   int fd_;
 #endif  // (defined _WIN32) || (defined _WIN64)
 
-  void open_(const char *filename);
+  void open_(const char *filename, int flags);
   void open_(const void *ptr, std::size_t size);
 
   const void *map_data(std::size_t size);

--- a/lib/marisa/trie.cc
+++ b/lib/marisa/trie.cc
@@ -19,14 +19,14 @@ void Trie::build(Keyset &keyset, int config_flags) {
   trie_.swap(temp);
 }
 
-void Trie::mmap(const char *filename) {
+void Trie::mmap(const char *filename, int flags) {
   MARISA_THROW_IF(filename == NULL, MARISA_NULL_ERROR);
 
   std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow) grimoire::LoudsTrie);
   MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
   grimoire::Mapper mapper;
-  mapper.open(filename);
+  mapper.open(filename, flags);
   temp->map(mapper);
   trie_.swap(temp);
 }

--- a/tests/io-test.cc
+++ b/tests/io-test.cc
@@ -71,6 +71,25 @@ void TestFilename() {
   }
 
   {
+    marisa::grimoire::Mapper mapper;
+    mapper.open("io-test.dat", MARISA_MAP_POPULATE);
+
+    marisa::UInt32 value;
+    mapper.map(&value);
+    ASSERT(value == 123);
+    mapper.map(&value);
+    ASSERT(value == 234);
+
+    const double *values;
+    mapper.map(&values, 2);
+    ASSERT(values[0] == 3.45);
+    ASSERT(values[1] == 4.56);
+
+    char byte;
+    EXCEPT(mapper.map(&byte), MARISA_IO_ERROR);
+  }
+
+  {
     marisa::grimoire::Writer writer;
     writer.open("io-test.dat");
   }


### PR DESCRIPTION
In order to support MAP_POPULATE, this pull request updates Trie::mmap() to accept the 2nd argument.
When MARISA_MAP_POPULATE is specified, Trie::mmap() passes MAP_POPULATE to mmap().

The flags are defined in include/marisa/base.h.
Currently, only MARISA_MAP_POPULATE is available.

This fixed #14.
