### PR TITLE
vector.h: fix a few clang-tidy warnings

### DIFF
--- a/include/marisa/agent.h
+++ b/include/marisa/agent.h
@@ -72,7 +72,7 @@ class Agent {
   }
 
   bool has_state() const {
-    return state_.get() != NULL;
+    return state_ != nullptr;
   }
   void init_state();
 

--- a/include/marisa/query.h
+++ b/include/marisa/query.h
@@ -12,15 +12,9 @@ namespace marisa {
 class Query {
  public:
   Query() : ptr_(NULL), length_(0), id_(0) {}
-  Query(const Query &query)
-      : ptr_(query.ptr_), length_(query.length_), id_(query.id_) {}
+  Query(const Query &query) = default;
 
-  Query &operator=(const Query &query) {
-    ptr_ = query.ptr_;
-    length_ = query.length_;
-    id_ = query.id_;
-    return *this;
-  }
+  Query &operator=(const Query &query) = default;
 
   char operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= length_, MARISA_BOUND_ERROR);

--- a/lib/marisa/grimoire/vector/vector.h
+++ b/lib/marisa/grimoire/vector/vector.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <new>
 #include <type_traits>
+#include <utility>
 
 #include "marisa/grimoire/io.h"
 
@@ -29,7 +30,7 @@ class Vector {
   Vector(const Vector<T> &other)
         : buf_(), objs_(NULL), const_objs_(NULL),
           size_(0), capacity_(0), fixed_(other.fixed_) {
-    if (other.buf_.get() == NULL) {
+    if (other.buf_ == nullptr) {
       objs_ = other.objs_;
       const_objs_ = other.const_objs_;
       size_ = other.size_;
@@ -42,7 +43,7 @@ class Vector {
   Vector &operator=(const Vector<T> &other) {
     clear();
     fixed_ = other.fixed_;
-    if (other.buf_.get() == NULL) {
+    if (other.buf_ == nullptr) {
       objs_ = other.objs_;
       const_objs_ = other.const_objs_;
       size_ = other.size_;
@@ -287,7 +288,7 @@ class Vector {
 
     buf_ = std::unique_ptr<char[]>(
         new (std::nothrow) char[sizeof(T) * capacity]);
-    MARISA_DEBUG_IF(buf_.get() == NULL, MARISA_MEMORY_ERROR);
+    MARISA_DEBUG_IF(buf_ == nullptr, MARISA_MEMORY_ERROR);
     T *new_objs = reinterpret_cast<T *>(buf_.get());
 
     if (std::is_trivially_copyable<T>::value) {


### PR DESCRIPTION
1. Missing `#include <utility>` for `std::move`
2. Redundant `get()` call on smart pointer

Once CMake support is merged, I can send a PR adding clang-tidy to CI (warnings will be displayed on GitHub PRs)