### PR TITLE
cmake: Fix ENABLE_NATIVE_BUILD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ function(check_macro_defined MACRO OUTPUT_VAR)
       "#ifndef ${MACRO}\n#error \"${MACRO} is missing\"\n#endif\n"
     COMPILE_DEFINITIONS -march=native
   )
+  set("${OUTPUT_VAR}" "${result}" PARENT_SCOPE)
   message("${OUTPUT_VAR}: ${result}")
 endfunction()
 if(ENABLE_NATIVE_CODE)


### PR DESCRIPTION
Was missing a call to set the output variable.

Fixes #79 

Interestingly, this decreases the performance on my machine (Ryzen 3950x) compared to just `-march=native` (as was before with the bug):

```
Number of tries: 1 - 5
TAIL mode: Text mode
Node order: Descending weight order
Cache level: Normal cache
Number of keys: 1000
Total length: 4650
------+----------+--------+--------+--------+--------+--------
#tries       size    build   lookup  reverse   prefix  predict
                                      lookup   search   search
          [bytes]    [K/s]    [K/s]    [K/s]    [K/s]    [K/s]
------+----------+--------+--------+--------+--------+--------
     1       7072  3355.70  8620.69  9259.26  6896.55  4587.16
     2       6904  3236.25  7042.25  7575.76  6134.97  3875.97
     3       7136  3125.00  6802.72  7462.69  5128.21  3717.47
     4       7448  2915.45  6451.61  7194.24  5464.48  3759.40
     5       7776  2994.01  6666.67  7194.24  5714.29  3787.88
------+----------+--------+--------+--------+--------+--------
```

After:

```
------+----------+--------+--------+--------+--------+--------
#tries       size    build   lookup  reverse   prefix  predict
                                      lookup   search   search
          [bytes]    [K/s]    [K/s]    [K/s]    [K/s]    [K/s]
------+----------+--------+--------+--------+--------+--------
     1       7072  3367.00  6756.76  3267.97  5617.98  3164.56
     2       6904  3246.75  4237.29  2544.53  3448.28  2012.07
     3       7136  2881.84  3875.97  2427.18  3597.12  1996.01
     4       7448  2865.33  3787.88  2386.63  3496.50  1934.24
     5       7776  2958.58  3802.28  2409.64  3484.32  1941.75
------+----------+--------+--------+--------+--------+--------
```

(file https://raw.githubusercontent.com/Numeri/wiki-wordlists/refs/heads/master/compiled-wordlists/als1000-alemannisch.txt)

Perhaps the compiler is doing something smarter for my particular CPU than whatever it is that we do with intrinsics.