### PR TITLE
Add and use .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+---
+BasedOnStyle: Google
+Language: Cpp
+# `AlignConsecutiveAssignments` controls all assignments.  We would like to
+# align just enum declarations, but it doesn't look like it's possible.
+# `AlignConsecutiveDeclarations: true` is good for typedefs, but bad for
+# member functions and variables.  Leave if off.
+AlignConsecutiveMacros: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+IndentPPDirectives: BeforeHash
+PPIndentWidth: 1
+PackConstructorInitializers: BinPack
+SpaceAfterCStyleCast: false
+...

--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -14,12 +14,12 @@ extern "C" {
 #endif  // __cplusplus
 
 #ifdef _MSC_VER
-typedef unsigned __int8  marisa_uint8;
+typedef unsigned __int8 marisa_uint8;
 typedef unsigned __int16 marisa_uint16;
 typedef unsigned __int32 marisa_uint32;
 typedef unsigned __int64 marisa_uint64;
-#else  // _MSC_VER
-typedef uint8_t  marisa_uint8;
+#else   // _MSC_VER
+typedef uint8_t marisa_uint8;
 typedef uint16_t marisa_uint16;
 typedef uint32_t marisa_uint32;
 typedef uint64_t marisa_uint64;
@@ -33,12 +33,12 @@ typedef uint64_t marisa_uint64;
  #error Failed to detect MARISA_WORD_SIZE
 #endif
 
-//#define MARISA_WORD_SIZE  (sizeof(void *) * 8)
+// #define MARISA_WORD_SIZE  (sizeof(void *) * 8)
 
-#define MARISA_UINT8_MAX  ((marisa_uint8)~(marisa_uint8)0)
-#define MARISA_UINT16_MAX ((marisa_uint16)~(marisa_uint16)0)
-#define MARISA_UINT32_MAX ((marisa_uint32)~(marisa_uint32)0)
-#define MARISA_UINT64_MAX ((marisa_uint64)~(marisa_uint64)0)
+#define MARISA_UINT8_MAX  ((marisa_uint8) ~(marisa_uint8)0)
+#define MARISA_UINT16_MAX ((marisa_uint16) ~(marisa_uint16)0)
+#define MARISA_UINT32_MAX ((marisa_uint32) ~(marisa_uint32)0)
+#define MARISA_UINT64_MAX ((marisa_uint64) ~(marisa_uint64)0)
 #define MARISA_SIZE_MAX   ((size_t)~(size_t)0)
 
 #define MARISA_INVALID_LINK_ID MARISA_UINT32_MAX
@@ -50,38 +50,38 @@ typedef uint64_t marisa_uint64;
 typedef enum marisa_error_code_ {
   // MARISA_OK means that a requested operation has succeeded. In practice, an
   // exception never has MARISA_OK because it is not an error.
-  MARISA_OK           = 0,
+  MARISA_OK = 0,
 
   // MARISA_STATE_ERROR means that an object was not ready for a requested
   // operation. For example, an operation to modify a fixed vector throws an
   // exception with MARISA_STATE_ERROR.
-  MARISA_STATE_ERROR  = 1,
+  MARISA_STATE_ERROR = 1,
 
   // MARISA_NULL_ERROR means that an invalid NULL pointer has been given.
-  MARISA_NULL_ERROR   = 2,
+  MARISA_NULL_ERROR = 2,
 
   // MARISA_BOUND_ERROR means that an operation has tried to access an out of
   // range address.
-  MARISA_BOUND_ERROR  = 3,
+  MARISA_BOUND_ERROR = 3,
 
   // MARISA_RANGE_ERROR means that an out of range value has appeared in
   // operation.
-  MARISA_RANGE_ERROR  = 4,
+  MARISA_RANGE_ERROR = 4,
 
   // MARISA_CODE_ERROR means that an undefined code has appeared in operation.
-  MARISA_CODE_ERROR   = 5,
+  MARISA_CODE_ERROR = 5,
 
   // MARISA_RESET_ERROR means that a smart pointer has tried to reset itself.
-  MARISA_RESET_ERROR  = 6,
+  MARISA_RESET_ERROR = 6,
 
   // MARISA_SIZE_ERROR means that a size has exceeded a library limitation.
-  MARISA_SIZE_ERROR   = 7,
+  MARISA_SIZE_ERROR = 7,
 
   // MARISA_MEMORY_ERROR means that a memory allocation has failed.
   MARISA_MEMORY_ERROR = 8,
 
   // MARISA_IO_ERROR means that an I/O operation has failed.
-  MARISA_IO_ERROR     = 9,
+  MARISA_IO_ERROR = 9,
 
   // MARISA_FORMAT_ERROR means that input was in invalid format.
   MARISA_FORMAT_ERROR = 10,
@@ -102,8 +102,8 @@ typedef enum marisa_map_flags {
 // A dictionary consists of 3 tries in default. Usually more tries make a
 // dictionary space-efficient but time-inefficient.
 typedef enum marisa_num_tries_ {
-  MARISA_MIN_NUM_TRIES     = 0x00001,
-  MARISA_MAX_NUM_TRIES     = 0x0007F,
+  MARISA_MIN_NUM_TRIES = 0x00001,
+  MARISA_MAX_NUM_TRIES = 0x0007F,
   MARISA_DEFAULT_NUM_TRIES = 0x00003,
 } marisa_num_tries;
 
@@ -111,12 +111,12 @@ typedef enum marisa_num_tries_ {
 // following enumerated type marisa_cache_level gives a list of available cache
 // size options. A larger cache enables faster search but takes a more space.
 typedef enum marisa_cache_level_ {
-  MARISA_HUGE_CACHE        = 0x00080,
-  MARISA_LARGE_CACHE       = 0x00100,
-  MARISA_NORMAL_CACHE      = 0x00200,
-  MARISA_SMALL_CACHE       = 0x00400,
-  MARISA_TINY_CACHE        = 0x00800,
-  MARISA_DEFAULT_CACHE     = MARISA_NORMAL_CACHE
+  MARISA_HUGE_CACHE = 0x00080,
+  MARISA_LARGE_CACHE = 0x00100,
+  MARISA_NORMAL_CACHE = 0x00200,
+  MARISA_SMALL_CACHE = 0x00400,
+  MARISA_TINY_CACHE = 0x00800,
+  MARISA_DEFAULT_CACHE = MARISA_NORMAL_CACHE
 } marisa_cache_level;
 
 // This library provides 2 kinds of TAIL implementations.
@@ -125,15 +125,15 @@ typedef enum marisa_tail_mode_ {
   // available if and only if the last labels do not contain a NULL character.
   // If MARISA_TEXT_TAIL is specified and a NULL character exists in the last
   // labels, the setting is automatically switched to MARISA_BINARY_TAIL.
-  MARISA_TEXT_TAIL         = 0x01000,
+  MARISA_TEXT_TAIL = 0x01000,
 
   // MARISA_BINARY_TAIL also merges last labels but as byte sequences. It uses
   // a bit vector to detect the end of a sequence, instead of NULL characters.
   // So, MARISA_BINARY_TAIL requires a larger space if the average length of
   // labels is greater than 8.
-  MARISA_BINARY_TAIL       = 0x02000,
+  MARISA_BINARY_TAIL = 0x02000,
 
-  MARISA_DEFAULT_TAIL      = MARISA_TEXT_TAIL,
+  MARISA_DEFAULT_TAIL = MARISA_TEXT_TAIL,
 } marisa_tail_mode;
 
 // The arrangement of nodes affects the time cost of matching and the order of
@@ -142,22 +142,22 @@ typedef enum marisa_node_order_ {
   // MARISA_LABEL_ORDER arranges nodes in ascending label order.
   // MARISA_LABEL_ORDER is useful if an application needs to predict keys in
   // label order.
-  MARISA_LABEL_ORDER       = 0x10000,
+  MARISA_LABEL_ORDER = 0x10000,
 
   // MARISA_WEIGHT_ORDER arranges nodes in descending weight order.
   // MARISA_WEIGHT_ORDER is generally a better choice because it enables faster
   // matching.
-  MARISA_WEIGHT_ORDER      = 0x20000,
+  MARISA_WEIGHT_ORDER = 0x20000,
 
-  MARISA_DEFAULT_ORDER     = MARISA_WEIGHT_ORDER,
+  MARISA_DEFAULT_ORDER = MARISA_WEIGHT_ORDER,
 } marisa_node_order;
 
 typedef enum marisa_config_mask_ {
-  MARISA_NUM_TRIES_MASK    = 0x0007F,
-  MARISA_CACHE_LEVEL_MASK  = 0x00F80,
-  MARISA_TAIL_MODE_MASK    = 0x0F000,
-  MARISA_NODE_ORDER_MASK   = 0xF0000,
-  MARISA_CONFIG_MASK       = 0xFFFFF
+  MARISA_NUM_TRIES_MASK = 0x0007F,
+  MARISA_CACHE_LEVEL_MASK = 0x00F80,
+  MARISA_TAIL_MODE_MASK = 0x0F000,
+  MARISA_NODE_ORDER_MASK = 0xF0000,
+  MARISA_CONFIG_MASK = 0xFFFFF
 } marisa_config_mask;
 
 #ifdef __cplusplus
@@ -166,11 +166,11 @@ typedef enum marisa_config_mask_ {
 
 #ifdef __cplusplus
 
-#include <utility>
+ #include <utility>
 
 namespace marisa {
 
-typedef ::marisa_uint8  UInt8;
+typedef ::marisa_uint8 UInt8;
 typedef ::marisa_uint16 UInt16;
 typedef ::marisa_uint32 UInt32;
 typedef ::marisa_uint64 UInt64;

--- a/include/marisa/exception.h
+++ b/include/marisa/exception.h
@@ -13,8 +13,8 @@ namespace marisa {
 //  "__FILE__:__LINE__: error_code: error_message"
 class Exception : public std::exception {
  public:
-  Exception(const char *filename, int line,
-      ErrorCode error_code, const char *error_message) noexcept
+  Exception(const char *filename, int line, ErrorCode error_code,
+            const char *error_message) noexcept
       : std::exception(), filename_(filename), line_(line),
         error_code_(error_code), error_message_(error_message) {}
   Exception(const Exception &ex) noexcept = default;
@@ -49,14 +49,15 @@ class Exception : public std::exception {
 // These macros are used to convert a line number to a string constant.
 #define MARISA_INT_TO_STR(value) #value
 #define MARISA_LINE_TO_STR(line) MARISA_INT_TO_STR(line)
-#define MARISA_LINE_STR MARISA_LINE_TO_STR(__LINE__)
+#define MARISA_LINE_STR          MARISA_LINE_TO_STR(__LINE__)
 
 // MARISA_THROW throws an exception with a filename, a line number, an error
 // code and an error message. The message format is as follows:
 //  "__FILE__:__LINE__: error_code: error_message"
-#define MARISA_THROW(error_code, error_message) \
-  (throw marisa::Exception(__FILE__, __LINE__, error_code, \
-       __FILE__ ":" MARISA_LINE_STR ": " #error_code ": " error_message))
+#define MARISA_THROW(error_code, error_message)                          \
+  (throw marisa::Exception(__FILE__, __LINE__, error_code,               \
+                           __FILE__ ":" MARISA_LINE_STR ": " #error_code \
+                                    ": " error_message))
 
 // MARISA_THROW_IF throws an exception if `condition' is true.
 #define MARISA_THROW_IF(condition, error_code) \

--- a/include/marisa/keyset.h
+++ b/include/marisa/keyset.h
@@ -5,7 +5,7 @@
 
 #if __cplusplus >= 201703L
  #include <string_view>
-#endif //  __cplusplus >= 201703L
+#endif  //  __cplusplus >= 201703L
 
 #include "marisa/key.h"
 
@@ -14,9 +14,9 @@ namespace marisa {
 class Keyset {
  public:
   enum {
-    BASE_BLOCK_SIZE  = 4096,
+    BASE_BLOCK_SIZE = 4096,
     EXTRA_BLOCK_SIZE = 1024,
-    KEY_BLOCK_SIZE   = 256
+    KEY_BLOCK_SIZE = 256
   };
 
   Keyset();
@@ -28,7 +28,7 @@ class Keyset {
   void push_back(std::string_view str, float weight = 1.0) {
     push_back(str.data(), str.length(), weight);
   }
-#endif // __cplusplus >= 201703L
+#endif  // __cplusplus >= 201703L
   void push_back(const char *str);
   void push_back(const char *ptr, std::size_t length, float weight = 1.0);
 

--- a/include/marisa/trie.h
+++ b/include/marisa/trie.h
@@ -3,8 +3,8 @@
 
 #include <memory>
 
-#include "marisa/keyset.h"
 #include "marisa/agent.h"
+#include "marisa/keyset.h"
 
 namespace marisa {
 namespace grimoire {

--- a/lib/marisa/agent.cc
+++ b/lib/marisa/agent.cc
@@ -1,7 +1,8 @@
+#include "marisa/agent.h"
+
 #include <new>
 #include <utility>
 
-#include "marisa/agent.h"
 #include "marisa/grimoire/trie.h"
 #include "marisa/grimoire/trie/state.h"
 #include "marisa/key.h"
@@ -32,8 +33,7 @@ Agent::Agent() : query_(), key_(), state_() {}
 Agent::~Agent() {}
 
 Agent::Agent(const Agent &other)
-    : query_(other.query_),
-      key_(other.key_),
+    : query_(other.query_), key_(other.key_),
       state_(other.has_state() ? new (std::nothrow)
                                      grimoire::trie::State(other.state())
                                : nullptr) {

--- a/lib/marisa/grimoire/algorithm/sort.h
+++ b/lib/marisa/grimoire/algorithm/sort.h
@@ -88,7 +88,7 @@ std::size_t sort(Iterator l, Iterator r, std::size_t depth) {
     Iterator pivot_r = r;
 
     const int pivot = median(*l, *(l + (r - l) / 2), *(r - 1), depth);
-    for ( ; ; ) {
+    for (;;) {
       while (pl < pr) {
         const int label = get_label(*pl, depth);
         if (label > pivot) {

--- a/lib/marisa/grimoire/intrin.h
+++ b/lib/marisa/grimoire/intrin.h
@@ -38,7 +38,7 @@
  #ifdef MARISA_USE_SSE2
   #undef MARISA_USE_SSE2
  #endif  // MARISA_USE_SSE2
-#endif  // defined(__i386__) || defined(_M_IX86)
+#endif   // defined(__i386__) || defined(_M_IX86)
 
 #ifdef MARISA_USE_BMI2
  #ifndef MARISA_USE_BMI
@@ -49,13 +49,13 @@
  #else  // _MSC_VER
   #include <x86intrin.h>
  #endif  // _MSC_VER
-#endif  // MARISA_USE_BMI2
+#endif   // MARISA_USE_BMI2
 
 #ifdef MARISA_USE_BMI
  #ifndef MARISA_USE_SSE4
   #define MARISA_USE_SSE4
  #endif  // MARISA_USE_SSE4
-#endif  // MARISA_USE_BMI
+#endif   // MARISA_USE_BMI
 
 #ifdef MARISA_USE_SSE4A
  #ifndef MARISA_USE_SSE3
@@ -64,13 +64,13 @@
  #ifndef MARISA_USE_POPCNT
   #define MARISA_USE_POPCNT
  #endif  // MARISA_USE_POPCNT
-#endif  // MARISA_USE_SSE4A
+#endif   // MARISA_USE_SSE4A
 
 #ifdef MARISA_USE_SSE4
  #ifndef MARISA_USE_SSE4_2
   #define MARISA_USE_SSE4_2
  #endif  // MARISA_USE_SSE4_2
-#endif  // MARISA_USE_SSE4
+#endif   // MARISA_USE_SSE4
 
 #ifdef MARISA_USE_SSE4_2
  #ifndef MARISA_USE_SSE4_1
@@ -79,13 +79,13 @@
  #ifndef MARISA_USE_POPCNT
   #define MARISA_USE_POPCNT
  #endif  // MARISA_USE_POPCNT
-#endif  // MARISA_USE_SSE4_2
+#endif   // MARISA_USE_SSE4_2
 
 #ifdef MARISA_USE_SSE4_1
  #ifndef MARISA_USE_SSSE3
   #define MARISA_USE_SSSE3
  #endif  // MARISA_USE_SSSE3
-#endif  // MARISA_USE_SSE4_1
+#endif   // MARISA_USE_SSE4_1
 
 #ifdef MARISA_USE_POPCNT
  #ifndef MARISA_USE_SSE3
@@ -96,7 +96,7 @@
  #else  // _MSC_VER
   #include <popcntintrin.h>
  #endif  // _MSC_VER
-#endif  // MARISA_USE_POPCNT
+#endif   // MARISA_USE_POPCNT
 
 #ifdef MARISA_USE_SSSE3
  #ifndef MARISA_USE_SSE3
@@ -114,7 +114,7 @@
  #ifndef MARISA_USE_SSE2
   #define MARISA_USE_SSE2
  #endif  // MARISA_USE_SSE2
-#endif  // MARISA_USE_SSE3
+#endif   // MARISA_USE_SSE3
 
 #ifdef MARISA_USE_SSE2
  #ifdef MARISA_X64
@@ -133,7 +133,7 @@
   #include <intrin.h>
   #pragma intrinsic(_BitScanForward)
  #endif  // MARISA_WORD_SIZE == 64
-#endif  // _MSC_VER
+#endif   // _MSC_VER
 
 #if defined(__aarch64__)
  #define MARISA_AARCH64

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -1,12 +1,12 @@
 #if (defined _WIN32) || (defined _WIN64)
- #include <sys/types.h>
  #include <sys/stat.h>
+ #include <sys/types.h>
  #include <windows.h>
 #else  // (defined _WIN32) || (defined _WIN64)
+ #include <fcntl.h>
  #include <sys/mman.h>
  #include <sys/stat.h>
  #include <sys/types.h>
- #include <fcntl.h>
  #include <unistd.h>
 #endif  // (defined _WIN32) || (defined _WIN64)
 
@@ -18,9 +18,8 @@ namespace io {
 
 #if (defined _WIN32) || (defined _WIN64)
 Mapper::Mapper()
-    : ptr_(NULL), origin_(NULL), avail_(0), size_(0),
-      file_(NULL), map_(NULL) {}
-#else  // (defined _WIN32) || (defined _WIN64)
+    : ptr_(NULL), origin_(NULL), avail_(0), size_(0), file_(NULL), map_(NULL) {}
+#else   // (defined _WIN32) || (defined _WIN64)
 Mapper::Mapper()
     : ptr_(NULL), origin_(MAP_FAILED), avail_(0), size_(0), fd_(-1) {}
 #endif  // (defined _WIN32) || (defined _WIN64)
@@ -39,7 +38,7 @@ Mapper::~Mapper() {
     ::CloseHandle(file_);
   }
 }
-#else  // (defined _WIN32) || (defined _WIN64)
+#else   // (defined _WIN32) || (defined _WIN64)
 Mapper::~Mapper() {
   if (origin_ != MAP_FAILED) {
     ::munmap(origin_, size_);
@@ -90,7 +89,7 @@ void Mapper::swap(Mapper &rhs) {
 #if (defined _WIN32) || (defined _WIN64)
   marisa::swap(file_, rhs.file_);
   marisa::swap(map_, rhs.map_);
-#else  // (defined _WIN32) || (defined _WIN64)
+#else   // (defined _WIN32) || (defined _WIN64)
   marisa::swap(fd_, rhs.fd_);
 #endif  // (defined _WIN32) || (defined _WIN64)
 }
@@ -99,7 +98,7 @@ const void *Mapper::map_data(std::size_t size) {
   MARISA_THROW_IF(!is_open(), MARISA_STATE_ERROR);
   MARISA_THROW_IF(size > avail_, MARISA_IO_ERROR);
 
-  const char * const data = static_cast<const char *>(ptr_);
+  const char *const data = static_cast<const char *>(ptr_);
   ptr_ = data + size;
   avail_ -= size;
   return data;
@@ -110,10 +109,10 @@ const void *Mapper::map_data(std::size_t size) {
   #if __MSVCRT_VERSION__ >= 0x0601
    #define MARISA_HAS_STAT64
   #endif  // __MSVCRT_VERSION__ >= 0x0601
- #endif  // __MSVCRT_VERSION__
+ #endif   // __MSVCRT_VERSION__
 void Mapper::open_(const char *filename, int flags) {
-  file_ = ::CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ,
-      NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  file_ = ::CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, NULL,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   MARISA_THROW_IF(file_ == INVALID_HANDLE_VALUE, MARISA_IO_ERROR);
 
   DWORD size_high, size_low;
@@ -142,11 +141,11 @@ void Mapper::open_(const char *filename, int flags) {
 
   int map_flags = MAP_SHARED;
   // `MAP_POPULATE` is Linux-specific.
-#ifdef MAP_POPULATE
+ #ifdef MAP_POPULATE
   if (flags & MARISA_MAP_POPULATE) {
     map_flags |= MAP_POPULATE;
   }
-#endif
+ #endif
 
   origin_ = ::mmap(NULL, size_, PROT_READ, map_flags, fd_, 0);
   MARISA_THROW_IF(origin_ == MAP_FAILED, MARISA_IO_ERROR);

--- a/lib/marisa/grimoire/io/mapper.h
+++ b/lib/marisa/grimoire/io/mapper.h
@@ -27,7 +27,7 @@ class Mapper {
   void map(const T **objs, std::size_t num_objs) {
     MARISA_THROW_IF((objs == NULL) && (num_objs != 0), MARISA_NULL_ERROR);
     MARISA_THROW_IF(num_objs > (MARISA_SIZE_MAX / sizeof(T)),
-        MARISA_SIZE_ERROR);
+                    MARISA_SIZE_ERROR);
     *objs = static_cast<const T *>(map_data(sizeof(T) * num_objs));
   }
 
@@ -46,7 +46,7 @@ class Mapper {
 #if (defined _WIN32) || (defined _WIN64)
   void *file_;
   void *map_;
-#else  // (defined _WIN32) || (defined _WIN64)
+#else   // (defined _WIN32) || (defined _WIN64)
   int fd_;
 #endif  // (defined _WIN32) || (defined _WIN64)
 

--- a/lib/marisa/grimoire/io/reader.cc
+++ b/lib/marisa/grimoire/io/reader.cc
@@ -14,8 +14,7 @@ namespace marisa {
 namespace grimoire {
 namespace io {
 
-Reader::Reader()
-    : file_(NULL), fd_(-1), stream_(NULL), needs_fclose_(false) {}
+Reader::Reader() : file_(NULL), fd_(-1), stream_(NULL), needs_fclose_(false) {}
 
 Reader::~Reader() {
   if (needs_fclose_) {
@@ -89,7 +88,7 @@ void Reader::open_(const char *filename) {
   std::FILE *file = NULL;
 #ifdef _MSC_VER
   MARISA_THROW_IF(::fopen_s(&file, filename, "rb") != 0, MARISA_IO_ERROR);
-#else  // _MSC_VER
+#else   // _MSC_VER
   file = ::fopen(filename, "rb");
   MARISA_THROW_IF(file == NULL, MARISA_IO_ERROR);
 #endif  // _MSC_VER
@@ -116,11 +115,10 @@ void Reader::read_data(void *buf, std::size_t size) {
   } else if (fd_ != -1) {
     while (size != 0) {
 #ifdef _WIN32
-      static const std::size_t CHUNK_SIZE =
-          std::numeric_limits<int>::max();
+      static const std::size_t CHUNK_SIZE = std::numeric_limits<int>::max();
       const unsigned int count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
       const int size_read = ::_read(fd_, buf, count);
-#else  // _WIN32
+#else   // _WIN32
       static const std::size_t CHUNK_SIZE =
           std::numeric_limits< ::ssize_t>::max();
       const ::size_t count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
@@ -135,7 +133,8 @@ void Reader::read_data(void *buf, std::size_t size) {
   } else if (stream_ != NULL) {
     try {
       MARISA_THROW_IF(!stream_->read(static_cast<char *>(buf),
-          static_cast<std::streamsize>(size)), MARISA_IO_ERROR);
+                                     static_cast<std::streamsize>(size)),
+                      MARISA_IO_ERROR);
     } catch (const std::ios_base::failure &) {
       MARISA_THROW(MARISA_IO_ERROR, "std::ios_base::failure");
     }

--- a/lib/marisa/grimoire/io/reader.h
+++ b/lib/marisa/grimoire/io/reader.h
@@ -30,7 +30,7 @@ class Reader {
   void read(T *objs, std::size_t num_objs) {
     MARISA_THROW_IF((objs == NULL) && (num_objs != 0), MARISA_NULL_ERROR);
     MARISA_THROW_IF(num_objs > (MARISA_SIZE_MAX / sizeof(T)),
-        MARISA_SIZE_ERROR);
+                    MARISA_SIZE_ERROR);
     read_data(objs, sizeof(T) * num_objs);
   }
 

--- a/lib/marisa/grimoire/io/writer.cc
+++ b/lib/marisa/grimoire/io/writer.cc
@@ -14,8 +14,7 @@ namespace marisa {
 namespace grimoire {
 namespace io {
 
-Writer::Writer()
-    : file_(NULL), fd_(-1), stream_(NULL), needs_fclose_(false) {}
+Writer::Writer() : file_(NULL), fd_(-1), stream_(NULL), needs_fclose_(false) {}
 
 Writer::~Writer() {
   if (needs_fclose_) {
@@ -89,7 +88,7 @@ void Writer::open_(const char *filename) {
   std::FILE *file = NULL;
 #ifdef _MSC_VER
   MARISA_THROW_IF(::fopen_s(&file, filename, "wb") != 0, MARISA_IO_ERROR);
-#else  // _MSC_VER
+#else   // _MSC_VER
   file = ::fopen(filename, "wb");
   MARISA_THROW_IF(file == NULL, MARISA_IO_ERROR);
 #endif  // _MSC_VER
@@ -116,11 +115,10 @@ void Writer::write_data(const void *data, std::size_t size) {
   } else if (fd_ != -1) {
     while (size != 0) {
 #ifdef _WIN32
-      static const std::size_t CHUNK_SIZE =
-          std::numeric_limits<int>::max();
+      static const std::size_t CHUNK_SIZE = std::numeric_limits<int>::max();
       const unsigned int count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
       const int size_written = ::_write(fd_, data, count);
-#else  // _WIN32
+#else   // _WIN32
       static const std::size_t CHUNK_SIZE =
           std::numeric_limits< ::ssize_t>::max();
       const ::size_t count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
@@ -136,7 +134,8 @@ void Writer::write_data(const void *data, std::size_t size) {
   } else if (stream_ != NULL) {
     try {
       MARISA_THROW_IF(!stream_->write(static_cast<const char *>(data),
-          static_cast<std::streamsize>(size)), MARISA_IO_ERROR);
+                                      static_cast<std::streamsize>(size)),
+                      MARISA_IO_ERROR);
     } catch (const std::ios_base::failure &) {
       MARISA_THROW(MARISA_IO_ERROR, "std::ios_base::failure");
     }

--- a/lib/marisa/grimoire/trie.h
+++ b/lib/marisa/grimoire/trie.h
@@ -1,14 +1,14 @@
 #ifndef MARISA_GRIMOIRE_TRIE_H_
 #define MARISA_GRIMOIRE_TRIE_H_
 
-#include "marisa/grimoire/trie/state.h"
 #include "marisa/grimoire/trie/louds-trie.h"
+#include "marisa/grimoire/trie/state.h"
 
 namespace marisa {
 namespace grimoire {
 
-using trie::State;
 using trie::LoudsTrie;
+using trie::State;
 
 }  // namespace grimoire
 }  // namespace marisa

--- a/lib/marisa/grimoire/trie/config.h
+++ b/lib/marisa/grimoire/trie/config.h
@@ -11,8 +11,7 @@ class Config {
  public:
   Config()
       : num_tries_(MARISA_DEFAULT_NUM_TRIES),
-        cache_level_(MARISA_DEFAULT_CACHE),
-        tail_mode_(MARISA_DEFAULT_TAIL),
+        cache_level_(MARISA_DEFAULT_CACHE), tail_mode_(MARISA_DEFAULT_TAIL),
         node_order_(MARISA_DEFAULT_ORDER) {}
 
   void parse(int config_flags) {
@@ -56,7 +55,7 @@ class Config {
 
   void parse_(int config_flags) {
     MARISA_THROW_IF((config_flags & ~MARISA_CONFIG_MASK) != 0,
-        MARISA_CODE_ERROR);
+                    MARISA_CODE_ERROR);
 
     parse_num_tries(config_flags);
     parse_cache_level(config_flags);

--- a/lib/marisa/grimoire/trie/header.h
+++ b/lib/marisa/grimoire/trie/header.h
@@ -34,7 +34,6 @@ class Header {
   }
 
  private:
-
   static const char *get_header() {
     static const char buf[HEADER_SIZE] = "We love Marisa.";
     return buf;
@@ -55,7 +54,7 @@ class Header {
 };
 
 }  // namespace trie
-}  // namespace marisa
 }  // namespace grimoire
+}  // namespace marisa
 
 #endif  // MARISA_GRIMOIRE_TRIE_HEADER_H_

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -1,3 +1,5 @@
+#include "marisa/grimoire/trie/louds-trie.h"
+
 #include <algorithm>
 #include <functional>
 #include <queue>
@@ -6,16 +8,15 @@
 #include "marisa/grimoire/trie/header.h"
 #include "marisa/grimoire/trie/range.h"
 #include "marisa/grimoire/trie/state.h"
-#include "marisa/grimoire/trie/louds-trie.h"
 
 namespace marisa {
 namespace grimoire {
 namespace trie {
 
 LoudsTrie::LoudsTrie()
-    : louds_(), terminal_flags_(), link_flags_(), bases_(), extras_(),
-      tail_(), next_trie_(), cache_(), cache_mask_(0), num_l1_nodes_(0),
-      config_(), mapper_() {}
+    : louds_(), terminal_flags_(), link_flags_(), bases_(), extras_(), tail_(),
+      next_trie_(), cache_(), cache_mask_(0), num_l1_nodes_(0), config_(),
+      mapper_() {}
 
 LoudsTrie::~LoudsTrie() {}
 
@@ -82,12 +83,12 @@ void LoudsTrie::reverse_lookup(Agent &agent) const {
     agent.set_key(agent.query().id());
     return;
   }
-  for ( ; ; ) {
+  for (;;) {
     if (link_flags_[state.node_id()]) {
       const std::size_t prev_key_pos = state.key_buf().size();
       restore(agent, get_link(state.node_id()));
       std::reverse(state.key_buf().begin() + prev_key_pos,
-          state.key_buf().end());
+                   state.key_buf().end());
     } else {
       state.key_buf().push_back((char)bases_[state.node_id()]);
     }
@@ -163,7 +164,7 @@ bool LoudsTrie::predictive_search(Agent &agent) const {
     }
   }
 
-  for ( ; ; ) {
+  for (;;) {
     if (state.history_pos() == state.history().size()) {
       const History &current = state.history().back();
       History next;
@@ -198,8 +199,7 @@ bool LoudsTrie::predictive_search(Agent &agent) const {
     } else if (state.history_pos() != 1) {
       History &current = state.history()[state.history_pos() - 1];
       current.set_node_id(current.node_id() + 1);
-      const History &prev =
-          state.history()[state.history_pos() - 2];
+      const History &prev = state.history()[state.history_pos() - 2];
       state.key_buf().resize(prev.key_pos());
       state.set_history_pos(state.history_pos() - 1);
     } else {
@@ -210,20 +210,21 @@ bool LoudsTrie::predictive_search(Agent &agent) const {
 }
 
 std::size_t LoudsTrie::total_size() const {
-  return louds_.total_size() + terminal_flags_.total_size()
-      + link_flags_.total_size() + bases_.total_size()
-      + extras_.total_size() + tail_.total_size()
-      + ((next_trie_.get() != NULL) ? next_trie_->total_size() : 0)
-      + cache_.total_size();
+  return louds_.total_size() + terminal_flags_.total_size() +
+         link_flags_.total_size() + bases_.total_size() + extras_.total_size() +
+         tail_.total_size() +
+         ((next_trie_.get() != NULL) ? next_trie_->total_size() : 0) +
+         cache_.total_size();
 }
 
 std::size_t LoudsTrie::io_size() const {
-  return Header().io_size() + louds_.io_size()
-      + terminal_flags_.io_size() + link_flags_.io_size()
-      + bases_.io_size() + extras_.io_size() + tail_.io_size()
-      + ((next_trie_.get() != NULL) ?
-          (next_trie_->io_size() - Header().io_size()) : 0)
-      + cache_.io_size() + (sizeof(UInt32) * 2);
+  return Header().io_size() + louds_.io_size() + terminal_flags_.io_size() +
+         link_flags_.io_size() + bases_.io_size() + extras_.io_size() +
+         tail_.io_size() +
+         ((next_trie_.get() != NULL)
+              ? (next_trie_->io_size() - Header().io_size())
+              : 0) +
+         cache_.io_size() + (sizeof(UInt32) * 2);
 }
 
 void LoudsTrie::clear() {
@@ -258,8 +259,8 @@ void LoudsTrie::build_(Keyset &keyset, const Config &config) {
 
   using TerminalIdPair = std::pair<UInt32, UInt32>;
   const std::size_t pairs_size = terminals.size();
-  std::unique_ptr<TerminalIdPair[]> pairs(
-      new (std::nothrow) TerminalIdPair[pairs_size]);
+  std::unique_ptr<TerminalIdPair[]> pairs(new (std::nothrow)
+                                              TerminalIdPair[pairs_size]);
   MARISA_THROW_IF(!pairs, MARISA_MEMORY_ERROR);
   for (std::size_t i = 0; i < pairs_size; ++i) {
     pairs[i].first = terminals[i];
@@ -292,8 +293,8 @@ void LoudsTrie::build_(Keyset &keyset, const Config &config) {
 }
 
 template <typename T>
-void LoudsTrie::build_trie(Vector<T> &keys,
-    Vector<UInt32> *terminals, const Config &config, std::size_t trie_id) {
+void LoudsTrie::build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+                           const Config &config, std::size_t trie_id) {
   build_current_trie(keys, terminals, config, trie_id);
 
   Vector<UInt32> next_terminals;
@@ -303,10 +304,10 @@ void LoudsTrie::build_trie(Vector<T> &keys,
 
   if (next_trie_.get() != NULL) {
     config_.parse(static_cast<int>((next_trie_->num_tries() + 1)) |
-        next_trie_->tail_mode() | next_trie_->node_order());
+                  next_trie_->tail_mode() | next_trie_->node_order());
   } else {
     config_.parse(1 | tail_.mode() | config.node_order() |
-        config.cache_level());
+                  config.cache_level());
   }
 
   link_flags_.build(false, false);
@@ -324,9 +325,9 @@ void LoudsTrie::build_trie(Vector<T> &keys,
 }
 
 template <typename T>
-void LoudsTrie::build_current_trie(Vector<T> &keys,
-    Vector<UInt32> *terminals, const Config &config,
-    std::size_t trie_id) try {
+void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+                                   const Config &config,
+                                   std::size_t trie_id) try {
   for (std::size_t i = 0; i < keys.size(); ++i) {
     keys[i].set_id(i);
   }
@@ -350,7 +351,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys,
     queue.pop();
 
     while ((range.begin() < range.end()) &&
-        (keys[range.begin()].length() == range.key_pos())) {
+           (keys[range.begin()].length() == range.key_pos())) {
       keys[range.begin()].set_terminal(node_id);
       range.set_begin(range.begin() + 1);
     }
@@ -364,18 +365,18 @@ void LoudsTrie::build_current_trie(Vector<T> &keys,
     double weight = keys[range.begin()].weight();
     for (std::size_t i = range.begin() + 1; i < range.end(); ++i) {
       if (keys[i - 1][range.key_pos()] != keys[i][range.key_pos()]) {
-        w_ranges.push_back(make_weighted_range(
-            range.begin(), i, range.key_pos(), (float)weight));
+        w_ranges.push_back(make_weighted_range(range.begin(), i,
+                                               range.key_pos(), (float)weight));
         range.set_begin(i);
         weight = 0.0;
       }
       weight += keys[i].weight();
     }
-    w_ranges.push_back(make_weighted_range(
-        range.begin(), range.end(), range.key_pos(), (float)weight));
+    w_ranges.push_back(make_weighted_range(range.begin(), range.end(),
+                                           range.key_pos(), (float)weight));
     if (config.node_order() == MARISA_WEIGHT_ORDER) {
       std::stable_sort(w_ranges.begin(), w_ranges.end(),
-          std::greater<WeightedRange>());
+                       std::greater<WeightedRange>());
     }
 
     if (node_id == 0) {
@@ -398,7 +399,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys,
         ++key_pos;
       }
       cache<T>(node_id, bases_.size(), w_range.weight(),
-          keys[w_range.begin()][w_range.key_pos()]);
+               keys[w_range.begin()][w_range.key_pos()]);
 
       if (key_pos == w_range.key_pos() + 1) {
         bases_.push_back(static_cast<unsigned char>(
@@ -409,7 +410,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys,
         link_flags_.push_back(true);
         T next_key;
         next_key.set_str(keys[w_range.begin()].ptr(),
-            keys[w_range.begin()].length());
+                         keys[w_range.begin()].length());
         next_key.substr(w_range.key_pos(), key_pos - w_range.key_pos());
         next_key.set_weight(w_range.weight());
         next_keys.push_back(next_key);
@@ -432,8 +433,8 @@ void LoudsTrie::build_current_trie(Vector<T> &keys,
 }
 
 template <>
-void LoudsTrie::build_next_trie(Vector<Key> &keys,
-    Vector<UInt32> *terminals, const Config &config, std::size_t trie_id) {
+void LoudsTrie::build_next_trie(Vector<Key> &keys, Vector<UInt32> *terminals,
+                                const Config &config, std::size_t trie_id) {
   if (trie_id == config.num_tries()) {
     Vector<Entry> entries;
     entries.resize(keys.size());
@@ -457,7 +458,8 @@ void LoudsTrie::build_next_trie(Vector<Key> &keys,
 
 template <>
 void LoudsTrie::build_next_trie(Vector<ReverseKey> &keys,
-    Vector<UInt32> *terminals, const Config &config, std::size_t trie_id) {
+                                Vector<UInt32> *terminals, const Config &config,
+                                std::size_t trie_id) {
   if (trie_id == config.num_tries()) {
     Vector<Entry> entries;
     entries.resize(keys.size());
@@ -474,7 +476,7 @@ void LoudsTrie::build_next_trie(Vector<ReverseKey> &keys,
 
 template <typename T>
 void LoudsTrie::build_terminals(const Vector<T> &keys,
-    Vector<UInt32> *terminals) const {
+                                Vector<UInt32> *terminals) const {
   Vector<UInt32> temp;
   temp.resize(keys.size());
   for (std::size_t i = 0; i < keys.size(); ++i) {
@@ -484,8 +486,8 @@ void LoudsTrie::build_terminals(const Vector<T> &keys,
 }
 
 template <>
-void LoudsTrie::cache<Key>(std::size_t parent, std::size_t child,
-    float weight, char label) {
+void LoudsTrie::cache<Key>(std::size_t parent, std::size_t child, float weight,
+                           char label) {
   MARISA_DEBUG_IF(parent >= child, MARISA_RANGE_ERROR);
 
   const std::size_t cache_id = get_cache_id(parent, label);
@@ -497,7 +499,7 @@ void LoudsTrie::cache<Key>(std::size_t parent, std::size_t child,
 }
 
 void LoudsTrie::reserve_cache(const Config &config, std::size_t trie_id,
-    std::size_t num_keys) {
+                              std::size_t num_keys) {
   std::size_t cache_size = (trie_id == 1) ? 256 : 1;
   while (cache_size < (num_keys / config.cache_level())) {
     cache_size *= 2;
@@ -508,7 +510,7 @@ void LoudsTrie::reserve_cache(const Config &config, std::size_t trie_id,
 
 template <>
 void LoudsTrie::cache<ReverseKey>(std::size_t parent, std::size_t child,
-    float weight, char) {
+                                  float weight, char) {
   MARISA_DEBUG_IF(parent >= child, MARISA_RANGE_ERROR);
 
   const std::size_t cache_id = get_cache_id(child);
@@ -524,8 +526,9 @@ void LoudsTrie::fill_cache() {
     const std::size_t node_id = cache_[i].child();
     if (node_id != 0) {
       cache_[i].set_base(bases_[node_id]);
-      cache_[i].set_extra(!link_flags_[node_id] ?
-          MARISA_INVALID_EXTRA : extras_[link_flags_.rank1(node_id)]);
+      cache_[i].set_extra(!link_flags_[node_id]
+                              ? MARISA_INVALID_EXTRA
+                              : extras_[link_flags_.rank1(node_id)]);
     } else {
       cache_[i].set_parent(MARISA_UINT32_MAX);
       cache_[i].set_child(MARISA_UINT32_MAX);
@@ -602,11 +605,11 @@ void LoudsTrie::write_(Writer &writer) const {
 
 bool LoudsTrie::find_child(Agent &agent) const {
   MARISA_DEBUG_IF(agent.state().query_pos() >= agent.query().length(),
-      MARISA_BOUND_ERROR);
+                  MARISA_BOUND_ERROR);
 
   State &state = agent.state();
-  const std::size_t cache_id = get_cache_id(state.node_id(),
-      agent.query()[state.query_pos()]);
+  const std::size_t cache_id =
+      get_cache_id(state.node_id(), agent.query()[state.query_pos()]);
   if (state.node_id() == cache_[cache_id].parent()) {
     if (cache_[cache_id].extra() != MARISA_INVALID_EXTRA) {
       if (!match(agent, cache_[cache_id].link())) {
@@ -635,7 +638,7 @@ bool LoudsTrie::find_child(Agent &agent) const {
         return false;
       }
     } else if (bases_[state.node_id()] ==
-        (UInt8)agent.query()[state.query_pos()]) {
+               (UInt8)agent.query()[state.query_pos()]) {
       state.set_query_pos(state.query_pos() + 1);
       return true;
     }
@@ -647,11 +650,11 @@ bool LoudsTrie::find_child(Agent &agent) const {
 
 bool LoudsTrie::predictive_find_child(Agent &agent) const {
   MARISA_DEBUG_IF(agent.state().query_pos() >= agent.query().length(),
-      MARISA_BOUND_ERROR);
+                  MARISA_BOUND_ERROR);
 
   State &state = agent.state();
-  const std::size_t cache_id = get_cache_id(state.node_id(),
-      agent.query()[state.query_pos()]);
+  const std::size_t cache_id =
+      get_cache_id(state.node_id(), agent.query()[state.query_pos()]);
   if (state.node_id() == cache_[cache_id].parent()) {
     if (cache_[cache_id].extra() != MARISA_INVALID_EXTRA) {
       if (!prefix_match(agent, cache_[cache_id].link())) {
@@ -681,7 +684,7 @@ bool LoudsTrie::predictive_find_child(Agent &agent) const {
         return false;
       }
     } else if (bases_[state.node_id()] ==
-        (UInt8)agent.query()[state.query_pos()]) {
+               (UInt8)agent.query()[state.query_pos()]) {
       state.key_buf().push_back((char)bases_[state.node_id()]);
       state.set_query_pos(state.query_pos() + 1);
       return true;
@@ -694,7 +697,7 @@ bool LoudsTrie::predictive_find_child(Agent &agent) const {
 
 void LoudsTrie::restore(Agent &agent, std::size_t link) const {
   if (next_trie_.get() != NULL) {
-    next_trie_->restore_(agent,  link);
+    next_trie_->restore_(agent, link);
   } else {
     tail_.restore(agent, link);
   }
@@ -720,11 +723,11 @@ void LoudsTrie::restore_(Agent &agent, std::size_t node_id) const {
   MARISA_DEBUG_IF(node_id == 0, MARISA_RANGE_ERROR);
 
   State &state = agent.state();
-  for ( ; ; ) {
+  for (;;) {
     const std::size_t cache_id = get_cache_id(node_id);
     if (node_id == cache_[cache_id].child()) {
       if (cache_[cache_id].extra() != MARISA_INVALID_EXTRA) {
-        restore(agent,  cache_[cache_id].link());
+        restore(agent, cache_[cache_id].link());
       } else {
         state.key_buf().push_back(cache_[cache_id].label());
       }
@@ -751,19 +754,18 @@ void LoudsTrie::restore_(Agent &agent, std::size_t node_id) const {
 
 bool LoudsTrie::match_(Agent &agent, std::size_t node_id) const {
   MARISA_DEBUG_IF(agent.state().query_pos() >= agent.query().length(),
-      MARISA_BOUND_ERROR);
+                  MARISA_BOUND_ERROR);
   MARISA_DEBUG_IF(node_id == 0, MARISA_RANGE_ERROR);
 
   State &state = agent.state();
-  for ( ; ; ) {
+  for (;;) {
     const std::size_t cache_id = get_cache_id(node_id);
     if (node_id == cache_[cache_id].child()) {
       if (cache_[cache_id].extra() != MARISA_INVALID_EXTRA) {
         if (!match(agent, cache_[cache_id].link())) {
           return false;
         }
-      } else if (cache_[cache_id].label() ==
-          agent.query()[state.query_pos()]) {
+      } else if (cache_[cache_id].label() == agent.query()[state.query_pos()]) {
         state.set_query_pos(state.query_pos() + 1);
       } else {
         return false;
@@ -803,19 +805,18 @@ bool LoudsTrie::match_(Agent &agent, std::size_t node_id) const {
 
 bool LoudsTrie::prefix_match_(Agent &agent, std::size_t node_id) const {
   MARISA_DEBUG_IF(agent.state().query_pos() >= agent.query().length(),
-      MARISA_BOUND_ERROR);
+                  MARISA_BOUND_ERROR);
   MARISA_DEBUG_IF(node_id == 0, MARISA_RANGE_ERROR);
 
   State &state = agent.state();
-  for ( ; ; ) {
+  for (;;) {
     const std::size_t cache_id = get_cache_id(node_id);
     if (node_id == cache_[cache_id].child()) {
       if (cache_[cache_id].extra() != MARISA_INVALID_EXTRA) {
         if (!prefix_match(agent, cache_[cache_id].link())) {
           return false;
         }
-      } else if (cache_[cache_id].label() ==
-          agent.query()[state.query_pos()]) {
+      } else if (cache_[cache_id].label() == agent.query()[state.query_pos()]) {
         state.key_buf().push_back(cache_[cache_id].label());
         state.set_query_pos(state.query_pos() + 1);
       } else {
@@ -860,18 +861,18 @@ std::size_t LoudsTrie::get_cache_id(std::size_t node_id) const {
 }
 
 std::size_t LoudsTrie::get_link(std::size_t node_id) const {
-  return  bases_[node_id] | (extras_[link_flags_.rank1(node_id)] * 256);
+  return bases_[node_id] | (extras_[link_flags_.rank1(node_id)] * 256);
 }
 
 std::size_t LoudsTrie::get_link(std::size_t node_id,
-    std::size_t link_id) const {
-  return  bases_[node_id] | (extras_[link_id] * 256);
+                                std::size_t link_id) const {
+  return bases_[node_id] | (extras_[link_id] * 256);
 }
 
 std::size_t LoudsTrie::update_link_id(std::size_t link_id,
-    std::size_t node_id) const {
-  return (link_id == MARISA_INVALID_LINK_ID) ?
-      link_flags_.rank1(node_id) : (link_id + 1);
+                                      std::size_t node_id) const {
+  return (link_id == MARISA_INVALID_LINK_ID) ? link_flags_.rank1(node_id)
+                                             : (link_id + 1);
 }
 
 }  // namespace trie

--- a/lib/marisa/grimoire/trie/louds-trie.h
+++ b/lib/marisa/grimoire/trie/louds-trie.h
@@ -3,19 +3,19 @@
 
 #include <memory>
 
-#include "marisa/keyset.h"
 #include "marisa/agent.h"
-#include "marisa/grimoire/vector.h"
+#include "marisa/grimoire/trie/cache.h"
 #include "marisa/grimoire/trie/config.h"
 #include "marisa/grimoire/trie/key.h"
 #include "marisa/grimoire/trie/tail.h"
-#include "marisa/grimoire/trie/cache.h"
+#include "marisa/grimoire/vector.h"
+#include "marisa/keyset.h"
 
 namespace marisa {
 namespace grimoire {
 namespace trie {
 
-class LoudsTrie  {
+class LoudsTrie {
  public:
   LoudsTrie();
   ~LoudsTrie();
@@ -80,23 +80,21 @@ class LoudsTrie  {
   void build_(Keyset &keyset, const Config &config);
 
   template <typename T>
-  void build_trie(Vector<T> &keys,
-      Vector<UInt32> *terminals, const Config &config, std::size_t trie_id);
+  void build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+                  const Config &config, std::size_t trie_id);
   template <typename T>
-  void build_current_trie(Vector<T> &keys,
-      Vector<UInt32> *terminals, const Config &config, std::size_t trie_id);
+  void build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+                          const Config &config, std::size_t trie_id);
   template <typename T>
-  void build_next_trie(Vector<T> &keys,
-      Vector<UInt32> *terminals, const Config &config, std::size_t trie_id);
+  void build_next_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+                       const Config &config, std::size_t trie_id);
   template <typename T>
-  void build_terminals(const Vector<T> &keys,
-      Vector<UInt32> *terminals) const;
+  void build_terminals(const Vector<T> &keys, Vector<UInt32> *terminals) const;
 
   void reserve_cache(const Config &config, std::size_t trie_id,
-      std::size_t num_keys);
+                     std::size_t num_keys);
   template <typename T>
-  void cache(std::size_t parent, std::size_t child,
-      float weight, char label);
+  void cache(std::size_t parent, std::size_t child, float weight, char label);
   void fill_cache();
 
   void map_(Mapper &mapper);
@@ -118,11 +116,10 @@ class LoudsTrie  {
   inline std::size_t get_cache_id(std::size_t node_id) const;
 
   inline std::size_t get_link(std::size_t node_id) const;
-  inline std::size_t get_link(std::size_t node_id,
-      std::size_t link_id) const;
+  inline std::size_t get_link(std::size_t node_id, std::size_t link_id) const;
 
   inline std::size_t update_link_id(std::size_t link_id,
-      std::size_t node_id) const;
+                                    std::size_t node_id) const;
 
   // Disallows copy and assignment.
   LoudsTrie(const LoudsTrie &);

--- a/lib/marisa/grimoire/trie/range.h
+++ b/lib/marisa/grimoire/trie/range.h
@@ -41,7 +41,7 @@ class Range {
 };
 
 inline Range make_range(std::size_t begin, std::size_t end,
-    std::size_t key_pos) {
+                        std::size_t key_pos) {
   Range range;
   range.set_begin(begin);
   range.set_end(end);
@@ -99,7 +99,7 @@ inline bool operator>(const WeightedRange &lhs, const WeightedRange &rhs) {
 }
 
 inline WeightedRange make_weighted_range(std::size_t begin, std::size_t end,
-    std::size_t key_pos, float weight) {
+                                         std::size_t key_pos, float weight) {
   WeightedRange range;
   range.set_begin(begin);
   range.set_end(end);

--- a/lib/marisa/grimoire/trie/state.h
+++ b/lib/marisa/grimoire/trie/state.h
@@ -1,8 +1,8 @@
 #ifndef MARISA_GRIMOIRE_TRIE_STATE_H_
 #define MARISA_GRIMOIRE_TRIE_STATE_H_
 
-#include "marisa/grimoire/vector.h"
 #include "marisa/grimoire/trie/history.h"
+#include "marisa/grimoire/vector.h"
 
 namespace marisa {
 namespace grimoire {
@@ -21,8 +21,8 @@ typedef enum StatusCode {
 class State {
  public:
   State()
-      : key_buf_(), history_(), node_id_(0), query_pos_(0),
-        history_pos_(0), status_code_(MARISA_READY_TO_ALL) {}
+      : key_buf_(), history_(), node_id_(0), query_pos_(0), history_pos_(0),
+        status_code_(MARISA_READY_TO_ALL) {}
 
   State(const State &) = default;
   State &operator=(const State &) = default;

--- a/lib/marisa/grimoire/trie/tail.cc
+++ b/lib/marisa/grimoire/trie/tail.cc
@@ -1,6 +1,7 @@
+#include "marisa/grimoire/trie/tail.h"
+
 #include "marisa/grimoire/algorithm.h"
 #include "marisa/grimoire/trie/state.h"
-#include "marisa/grimoire/trie/tail.h"
 
 namespace marisa {
 namespace grimoire {
@@ -9,13 +10,13 @@ namespace trie {
 Tail::Tail() : buf_(), end_flags_() {}
 
 void Tail::build(Vector<Entry> &entries, Vector<UInt32> *offsets,
-    TailMode mode) {
+                 TailMode mode) {
   MARISA_THROW_IF(offsets == NULL, MARISA_NULL_ERROR);
 
   switch (mode) {
     case MARISA_TEXT_TAIL: {
       for (std::size_t i = 0; i < entries.size(); ++i) {
-        const char * const ptr = entries[i].ptr();
+        const char *const ptr = entries[i].ptr();
         const std::size_t length = entries[i].length();
         for (std::size_t j = 0; j < length; ++j) {
           if (ptr[j] == '\0') {
@@ -76,11 +77,11 @@ void Tail::restore(Agent &agent, std::size_t offset) const {
 bool Tail::match(Agent &agent, std::size_t offset) const {
   MARISA_DEBUG_IF(buf_.empty(), MARISA_STATE_ERROR);
   MARISA_DEBUG_IF(agent.state().query_pos() >= agent.query().length(),
-      MARISA_BOUND_ERROR);
+                  MARISA_BOUND_ERROR);
 
   State &state = agent.state();
   if (end_flags_.empty()) {
-    const char * const ptr = &buf_[offset] - state.query_pos();
+    const char *const ptr = &buf_[offset] - state.query_pos();
     do {
       if (ptr[state.query_pos()] != agent.query()[state.query_pos()]) {
         return false;
@@ -154,7 +155,7 @@ void Tail::swap(Tail &rhs) {
 }
 
 void Tail::build_(Vector<Entry> &entries, Vector<UInt32> *offsets,
-    TailMode mode) {
+                  TailMode mode) {
   for (std::size_t i = 0; i < entries.size(); ++i) {
     entries[i].set_id(i);
   }
@@ -170,12 +171,12 @@ void Tail::build_(Vector<Entry> &entries, Vector<UInt32> *offsets,
     MARISA_THROW_IF(current.length() == 0, MARISA_RANGE_ERROR);
     std::size_t match = 0;
     while ((match < current.length()) && (match < last->length()) &&
-        ((*last)[match] == current[match])) {
+           ((*last)[match] == current[match])) {
       ++match;
     }
     if ((match == current.length()) && (last->length() != 0)) {
-      temp_offsets[current.id()] = (UInt32)(
-          temp_offsets[last->id()] + (last->length() - match));
+      temp_offsets[current.id()] =
+          (UInt32)(temp_offsets[last->id()] + (last->length() - match));
     } else {
       temp_offsets[current.id()] = (UInt32)buf_.size();
       for (std::size_t j = 1; j <= current.length(); ++j) {

--- a/lib/marisa/grimoire/trie/tail.h
+++ b/lib/marisa/grimoire/trie/tail.h
@@ -2,8 +2,8 @@
 #define MARISA_GRIMOIRE_TRIE_TAIL_H_
 
 #include "marisa/agent.h"
-#include "marisa/grimoire/vector.h"
 #include "marisa/grimoire/trie/entry.h"
+#include "marisa/grimoire/vector.h"
 
 namespace marisa {
 namespace grimoire {
@@ -13,8 +13,7 @@ class Tail {
  public:
   Tail();
 
-  void build(Vector<Entry> &entries, Vector<UInt32> *offsets,
-      TailMode mode);
+  void build(Vector<Entry> &entries, Vector<UInt32> *offsets, TailMode mode);
 
   void map(Mapper &mapper);
   void read(Reader &reader);
@@ -53,8 +52,7 @@ class Tail {
   Vector<char> buf_;
   BitVector end_flags_;
 
-  void build_(Vector<Entry> &entries, Vector<UInt32> *offsets,
-      TailMode mode);
+  void build_(Vector<Entry> &entries, Vector<UInt32> *offsets, TailMode mode);
 
   void map_(Mapper &mapper);
   void read_(Reader &reader);

--- a/lib/marisa/grimoire/vector.h
+++ b/lib/marisa/grimoire/vector.h
@@ -1,9 +1,9 @@
 #ifndef MARISA_GRIMOIRE_VECTOR_H_
 #define MARISA_GRIMOIRE_VECTOR_H_
 
-#include "marisa/grimoire/vector/vector.h"
-#include "marisa/grimoire/vector/flat-vector.h"
 #include "marisa/grimoire/vector/bit-vector.h"
+#include "marisa/grimoire/vector/flat-vector.h"
+#include "marisa/grimoire/vector/vector.h"
 
 namespace marisa {
 namespace grimoire {

--- a/lib/marisa/grimoire/vector/bit-vector.h
+++ b/lib/marisa/grimoire/vector/bit-vector.h
@@ -12,7 +12,7 @@ class BitVector {
  public:
 #if MARISA_WORD_SIZE == 64
   typedef UInt64 Unit;
-#else  // MARISA_WORD_SIZE == 64
+#else   // MARISA_WORD_SIZE == 64
   typedef UInt32 Unit;
 #endif  // MARISA_WORD_SIZE == 64
 
@@ -54,8 +54,7 @@ class BitVector {
       units_.resize(units_.size() + (64 / MARISA_WORD_SIZE), 0);
     }
     if (bit) {
-      units_[size_ / MARISA_WORD_SIZE] |=
-          (Unit)1 << (size_ % MARISA_WORD_SIZE);
+      units_[size_ / MARISA_WORD_SIZE] |= (Unit)1 << (size_ % MARISA_WORD_SIZE);
       ++num_1s_;
     }
     ++size_;
@@ -63,8 +62,8 @@ class BitVector {
 
   bool operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= size_, MARISA_BOUND_ERROR);
-    return (units_[i / MARISA_WORD_SIZE]
-        & ((Unit)1 << (i % MARISA_WORD_SIZE))) != 0;
+    return (units_[i / MARISA_WORD_SIZE] &
+            ((Unit)1 << (i % MARISA_WORD_SIZE))) != 0;
   }
 
   std::size_t rank0(std::size_t i) const {
@@ -91,12 +90,12 @@ class BitVector {
     return size_;
   }
   std::size_t total_size() const {
-    return units_.total_size() + ranks_.total_size()
-        + select0s_.total_size() + select1s_.total_size();
+    return units_.total_size() + ranks_.total_size() + select0s_.total_size() +
+           select1s_.total_size();
   }
   std::size_t io_size() const {
-    return units_.io_size() + (sizeof(UInt32) * 2) + ranks_.io_size()
-        + select0s_.io_size() + select1s_.io_size();
+    return units_.io_size() + (sizeof(UInt32) * 2) + ranks_.io_size() +
+           select0s_.io_size() + select1s_.io_size();
   }
 
   void clear() {
@@ -119,8 +118,8 @@ class BitVector {
   Vector<UInt32> select0s_;
   Vector<UInt32> select1s_;
 
-  void build_index(const BitVector &bv,
-      bool enables_select0, bool enables_select1);
+  void build_index(const BitVector &bv, bool enables_select0,
+                   bool enables_select1);
 
   void map_(Mapper &mapper) {
     units_.map(mapper);

--- a/lib/marisa/grimoire/vector/flat-vector.h
+++ b/lib/marisa/grimoire/vector/flat-vector.h
@@ -11,7 +11,7 @@ class FlatVector {
  public:
 #if MARISA_WORD_SIZE == 64
   typedef UInt64 Unit;
-#else  // MARISA_WORD_SIZE == 64
+#else   // MARISA_WORD_SIZE == 64
   typedef UInt32 Unit;
 #endif  // MARISA_WORD_SIZE == 64
 
@@ -47,8 +47,10 @@ class FlatVector {
     if ((unit_offset + value_size_) <= MARISA_WORD_SIZE) {
       return (UInt32)(units_[unit_id] >> unit_offset) & mask_;
     } else {
-      return (UInt32)((units_[unit_id] >> unit_offset)
-          | (units_[unit_id + 1] << (MARISA_WORD_SIZE - unit_offset))) & mask_;
+      return (UInt32)((units_[unit_id] >> unit_offset) |
+                      (units_[unit_id + 1]
+                       << (MARISA_WORD_SIZE - unit_offset))) &
+             mask_;
     }
   }
 
@@ -104,9 +106,9 @@ class FlatVector {
 
     std::size_t num_units = values.empty() ? 0 : (64 / MARISA_WORD_SIZE);
     if (value_size != 0) {
-      num_units = (std::size_t)(
-          (((UInt64)value_size * values.size()) + (MARISA_WORD_SIZE - 1))
-          / MARISA_WORD_SIZE);
+      num_units = (std::size_t)((((UInt64)value_size * values.size()) +
+                                 (MARISA_WORD_SIZE - 1)) /
+                                MARISA_WORD_SIZE);
       num_units += num_units % (64 / MARISA_WORD_SIZE);
     }
 
@@ -186,8 +188,7 @@ class FlatVector {
     units_[unit_id] &= ~((Unit)mask_ << unit_offset);
     units_[unit_id] |= (Unit)(value & mask_) << unit_offset;
     if ((unit_offset + value_size_) > MARISA_WORD_SIZE) {
-      units_[unit_id + 1] &=
-          ~((Unit)mask_ >> (MARISA_WORD_SIZE - unit_offset));
+      units_[unit_id + 1] &= ~((Unit)mask_ >> (MARISA_WORD_SIZE - unit_offset));
       units_[unit_id + 1] |=
           (Unit)(value & mask_) >> (MARISA_WORD_SIZE - unit_offset);
     }

--- a/lib/marisa/grimoire/vector/pop-count.h
+++ b/lib/marisa/grimoire/vector/pop-count.h
@@ -2,7 +2,7 @@
 #define MARISA_GRIMOIRE_VECTOR_POP_COUNT_H_
 
 #if __cplusplus >= 202002L
-#include <bit>
+ #include <bit>
 #endif
 
 #include "marisa/grimoire/intrin.h"
@@ -12,9 +12,9 @@ namespace grimoire {
 namespace vector {
 
 #ifdef __has_builtin
-#define MARISA_HAS_BUILTIN(x) __has_builtin(x)
+ #define MARISA_HAS_BUILTIN(x) __has_builtin(x)
 #else
-#define MARISA_HAS_BUILTIN(x) 0
+ #define MARISA_HAS_BUILTIN(x) 0
 #endif
 
 #if MARISA_WORD_SIZE == 64
@@ -55,24 +55,24 @@ class PopCount {
   }
 
   static std::size_t count(UInt64 x) {
-#if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
+ #if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
     return std::popcount(x);
-#elif MARISA_HAS_BUILTIN(__builtin_popcountll)
+ #elif MARISA_HAS_BUILTIN(__builtin_popcountll)
     static_assert(sizeof(x) == sizeof(unsigned long long),
                   "__builtin_popcountll does not take 64-bit arg");
     return __builtin_popcountll(x);
-#elif defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
- #ifdef _MSC_VER
+ #elif defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
+  #ifdef _MSC_VER
     return __popcnt64(x);
- #else  // _MSC_VER
+  #else   // _MSC_VER
     return static_cast<std::size_t>(_mm_popcnt_u64(x));
- #endif  // _MSC_VER
-#elif defined(MARISA_AARCH64)
+  #endif  // _MSC_VER
+ #elif defined(MARISA_AARCH64)
     // Byte-wise popcount followed by horizontal add.
     return vaddv_u8(vcnt_u8(vcreate_u8(x)));
-#else  // defined(MARISA_AARCH64)
+ #else   // defined(MARISA_AARCH64)
     return PopCount(x).lo64();
-#endif  // defined(MARISA_AARCH64)
+ #endif  // defined(MARISA_AARCH64)
   }
 
  private:
@@ -105,21 +105,21 @@ class PopCount {
   }
 
   static std::size_t count(UInt32 x) {
-#if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
+ #if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
     return std::popcount(x);
-#elif MARISA_HAS_BUILTIN(__builtin_popcount)
+ #elif MARISA_HAS_BUILTIN(__builtin_popcount)
     static_assert(sizeof(x) == sizeof(unsigned int),
                   "__builtin_popcount does not take 32-bit arg");
     return __builtin_popcount(x);
-#elif defined(MARISA_USE_POPCNT)
- #ifdef _MSC_VER
+ #elif defined(MARISA_USE_POPCNT)
+  #ifdef _MSC_VER
     return __popcnt(x);
- #else  // _MSC_VER
+  #else   // _MSC_VER
     return _mm_popcnt_u32(x);
- #endif  // _MSC_VER
-#else  // MARISA_USE_POPCNT
+  #endif  // _MSC_VER
+ #else    // MARISA_USE_POPCNT
     return PopCount(x).lo32();
-#endif  // MARISA_USE_POPCNT
+ #endif   // MARISA_USE_POPCNT
   }
 
  private:

--- a/lib/marisa/grimoire/vector/vector.h
+++ b/lib/marisa/grimoire/vector/vector.h
@@ -17,8 +17,8 @@ template <typename T>
 class Vector {
  public:
   Vector()
-      : buf_(), objs_(NULL), const_objs_(NULL),
-        size_(0), capacity_(0), fixed_(false) {}
+      : buf_(), objs_(NULL), const_objs_(NULL), size_(0), capacity_(0),
+        fixed_(false) {}
   ~Vector() {
     if (objs_ != NULL) {
       for (std::size_t i = 0; i < size_; ++i) {
@@ -28,8 +28,8 @@ class Vector {
   }
 
   Vector(const Vector<T> &other)
-        : buf_(), objs_(NULL), const_objs_(NULL),
-          size_(0), capacity_(0), fixed_(other.fixed_) {
+      : buf_(), objs_(NULL), const_objs_(NULL), size_(0), capacity_(0),
+        fixed_(other.fixed_) {
     if (other.buf_ == nullptr) {
       objs_ = other.objs_;
       const_objs_ = other.const_objs_;
@@ -286,8 +286,8 @@ class Vector {
   void copyInit(const T *src, std::size_t size, std::size_t capacity) {
     MARISA_DEBUG_IF(size_ > 0, MARISA_CODE_ERROR);
 
-    buf_ = std::unique_ptr<char[]>(
-        new (std::nothrow) char[sizeof(T) * capacity]);
+    buf_ =
+        std::unique_ptr<char[]>(new (std::nothrow) char[sizeof(T) * capacity]);
     MARISA_DEBUG_IF(buf_ == nullptr, MARISA_MEMORY_ERROR);
     T *new_objs = reinterpret_cast<T *>(buf_.get());
 

--- a/lib/marisa/keyset.cc
+++ b/lib/marisa/keyset.cc
@@ -1,21 +1,21 @@
+#include "marisa/keyset.h"
+
 #include <cstring>
 #include <memory>
 #include <new>
-
-#include "marisa/keyset.h"
 
 namespace marisa {
 
 Keyset::Keyset()
     : base_blocks_(), base_blocks_size_(0), base_blocks_capacity_(0),
       extra_blocks_(), extra_blocks_size_(0), extra_blocks_capacity_(0),
-      key_blocks_(), key_blocks_size_(0), key_blocks_capacity_(0),
-      ptr_(NULL), avail_(0), size_(0), total_length_(0) {}
+      key_blocks_(), key_blocks_size_(0), key_blocks_capacity_(0), ptr_(NULL),
+      avail_(0), size_(0), total_length_(0) {}
 
 void Keyset::push_back(const Key &key) {
   MARISA_DEBUG_IF(size_ == MARISA_SIZE_MAX, MARISA_SIZE_ERROR);
 
-  char * const key_ptr = reserve(key.length());
+  char *const key_ptr = reserve(key.length());
   std::memcpy(key_ptr, key.ptr(), key.length());
 
   Key &new_key = key_blocks_[size_ / KEY_BLOCK_SIZE][size_ % KEY_BLOCK_SIZE];
@@ -32,7 +32,7 @@ void Keyset::push_back(const Key &key, char end_marker) {
     append_key_block();
   }
 
-  char * const key_ptr = reserve(key.length() + 1);
+  char *const key_ptr = reserve(key.length() + 1);
   std::memcpy(key_ptr, key.ptr(), key.length());
   key_ptr[key.length()] = end_marker;
 
@@ -59,7 +59,7 @@ void Keyset::push_back(const char *ptr, std::size_t length, float weight) {
   MARISA_THROW_IF((ptr == NULL) && (length != 0), MARISA_NULL_ERROR);
   MARISA_THROW_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
 
-  char * const key_ptr = reserve(length);
+  char *const key_ptr = reserve(length);
   std::memcpy(key_ptr, ptr, length);
 
   Key &key = key_blocks_[size_ / KEY_BLOCK_SIZE][size_ % KEY_BLOCK_SIZE];

--- a/lib/marisa/trie.cc
+++ b/lib/marisa/trie.cc
@@ -1,9 +1,10 @@
+#include "marisa/trie.h"
+
 #include <memory>
 
-#include "marisa/stdio.h"
-#include "marisa/iostream.h"
-#include "marisa/trie.h"
 #include "marisa/grimoire/trie.h"
+#include "marisa/iostream.h"
+#include "marisa/stdio.h"
 
 namespace marisa {
 
@@ -16,7 +17,8 @@ Trie::Trie(Trie &&other) noexcept = default;
 Trie &Trie::operator=(Trie &&other) noexcept = default;
 
 void Trie::build(Keyset &keyset, int config_flags) {
-  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow) grimoire::LoudsTrie);
+  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                grimoire::LoudsTrie);
   MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
   temp->build(keyset, config_flags);
@@ -26,7 +28,8 @@ void Trie::build(Keyset &keyset, int config_flags) {
 void Trie::mmap(const char *filename, int flags) {
   MARISA_THROW_IF(filename == NULL, MARISA_NULL_ERROR);
 
-  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow) grimoire::LoudsTrie);
+  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                grimoire::LoudsTrie);
   MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
   grimoire::Mapper mapper;
@@ -38,7 +41,8 @@ void Trie::mmap(const char *filename, int flags) {
 void Trie::map(const void *ptr, std::size_t size) {
   MARISA_THROW_IF((ptr == NULL) && (size != 0), MARISA_NULL_ERROR);
 
-  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow) grimoire::LoudsTrie);
+  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                grimoire::LoudsTrie);
   MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
   grimoire::Mapper mapper;
@@ -50,7 +54,8 @@ void Trie::map(const void *ptr, std::size_t size) {
 void Trie::load(const char *filename) {
   MARISA_THROW_IF(filename == NULL, MARISA_NULL_ERROR);
 
-  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow) grimoire::LoudsTrie);
+  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                grimoire::LoudsTrie);
   MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
   grimoire::Reader reader;
@@ -62,7 +67,8 @@ void Trie::load(const char *filename) {
 void Trie::read(int fd) {
   MARISA_THROW_IF(fd == -1, MARISA_CODE_ERROR);
 
-  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow) grimoire::LoudsTrie);
+  std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                grimoire::LoudsTrie);
   MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
   grimoire::Reader reader;
@@ -185,8 +191,8 @@ class TrieIO {
   static void fread(std::FILE *file, Trie *trie) {
     MARISA_THROW_IF(trie == NULL, MARISA_NULL_ERROR);
 
-    std::unique_ptr<grimoire::LoudsTrie> temp(
-        new (std::nothrow) grimoire::LoudsTrie);
+    std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                  grimoire::LoudsTrie);
     MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
     grimoire::Reader reader;
@@ -205,8 +211,8 @@ class TrieIO {
   static std::istream &read(std::istream &stream, Trie *trie) {
     MARISA_THROW_IF(trie == NULL, MARISA_NULL_ERROR);
 
-    std::unique_ptr<grimoire::LoudsTrie> temp(
-        new (std::nothrow) grimoire::LoudsTrie);
+    std::unique_ptr<grimoire::LoudsTrie> temp(new (std::nothrow)
+                                                  grimoire::LoudsTrie);
     MARISA_THROW_IF(temp.get() == NULL, MARISA_MEMORY_ERROR);
 
     grimoire::Reader reader;


### PR DESCRIPTION
Reformat all files with
```
clang-format -i lib/**/*.{h,cc} include/**/*.h
```

Some of the existing formatting conventions could not be replicated with clang-format (see the diffs).  The most notable is the alignment of enum definitions.  marisa code likes these to be aligned, but clang-format only has an `AlignConsecutiveAssignments` option that controls all assignments.