### PR TITLE
Enable MARISA_MAP_POPULATE on FreeBSD and Windows

### DIFF
--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -126,6 +126,13 @@ void Mapper::open_(const char *filename, int flags) {
   origin_ = ::MapViewOfFile(map_, FILE_MAP_READ, 0, 0, 0);
   MARISA_THROW_IF(origin_ == NULL, MARISA_IO_ERROR);
 
+  if (flags & MARISA_MAP_POPULATE) {
+    WIN32_MEMORY_RANGE_ENTRY range_entry;
+    range_entry.VirtualAddress = origin_;
+    range_entry.NumberOfBytes = size_;
+    PrefetchVirtualMemory(GetCurrentProcess(), 1, &range_entry, 0);
+  }
+
   ptr_ = static_cast<const char *>(origin_);
   avail_ = size_;
 }

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -140,10 +140,15 @@ void Mapper::open_(const char *filename, int flags) {
   size_ = (std::size_t)st.st_size;
 
   int map_flags = MAP_SHARED;
+ #if defined(MAP_POPULATE)
   // `MAP_POPULATE` is Linux-specific.
- #ifdef MAP_POPULATE
   if (flags & MARISA_MAP_POPULATE) {
     map_flags |= MAP_POPULATE;
+  }
+ #elif defined(MAP_PREFAULT_READ)
+  // `MAP_PREFAULT_READ` is FreeBSD-specific.
+  if (flags & MARISA_MAP_POPULATE) {
+    map_flags |= MAP_PREFAULT_READ;
   }
  #endif
 


### PR DESCRIPTION
The current implementation uses MAP_POPULATE and it is linux-specific.

FreeBSD provides a similar flag MAP_PREFAULT_READ.
Windows provides a function PrefetchVirtualMemory() to prefetch virtual address ranges.

This also fixes #81.
