### PR TITLE
PopCount::count: Rename to popcount

### DIFF
--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -244,7 +244,7 @@ std::size_t select_bit(std::size_t i, std::size_t bit_id, UInt64 unit) {
     __m128i x = _mm_cvtsi64_si128(static_cast<long long>((i + 1) * MASK_01));
     __m128i y = _mm_cvtsi64_si128(static_cast<long long>(counts));
     x = _mm_cmpgt_epi8(x, y);
-    skip = (UInt8)PopCount::count(static_cast<UInt64>(_mm_cvtsi128_si64(x)));
+    skip = (UInt8)popcount(static_cast<UInt64>(_mm_cvtsi128_si64(x)));
   }
   #else  // defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
   const UInt64 x = (counts + PREFIX_SUM_OVERFLOW[i]) & MASK_80;
@@ -495,7 +495,7 @@ std::size_t BitVector::rank1(std::size_t i) const {
       break;
     }
   }
-  offset += PopCount::count(units_[i / 64] & ((1ULL << (i % 64)) - 1));
+  offset += popcount(units_[i / 64] & ((1ULL << (i % 64)) - 1));
   return offset;
 }
 
@@ -662,9 +662,9 @@ std::size_t BitVector::rank1(std::size_t i) const {
     }
   }
   if (((i / 32) & 1) == 1) {
-    offset += PopCount::count(units_[(i / 32) - 1]);
+    offset += popcount(units_[(i / 32) - 1]);
   }
-  offset += PopCount::count(units_[i / 32] & ((1U << (i % 32)) - 1));
+  offset += popcount(units_[i / 32] & ((1U << (i % 32)) - 1));
   return offset;
 }
 
@@ -847,7 +847,7 @@ void BitVector::build_index(const BitVector &bv, bool enables_select0,
     const Unit unit = bv.units_[unit_id];
     // push_back resizes with 0, so the high bits of the last unit are 0 and
     // do not affect the 1s count.
-    const std::size_t unit_num_1s = PopCount::count(unit);
+    const std::size_t unit_num_1s = popcount(unit);
 
     if (enables_select0) {
       // num_0s is somewhat move involved to compute, so only do it if we

--- a/lib/marisa/grimoire/vector/pop-count.h
+++ b/lib/marisa/grimoire/vector/pop-count.h
@@ -11,124 +11,70 @@ namespace marisa {
 namespace grimoire {
 namespace vector {
 
-#ifdef __has_builtin
- #define MARISA_HAS_BUILTIN(x) __has_builtin(x)
-#else
- #define MARISA_HAS_BUILTIN(x) 0
-#endif
+#if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 
-#if MARISA_WORD_SIZE == 64
+using std::popcount;
 
-class PopCount {
- public:
-  explicit PopCount(UInt64 x) : value_() {
-    x = (x & 0x5555555555555555ULL) + ((x & 0xAAAAAAAAAAAAAAAAULL) >> 1);
-    x = (x & 0x3333333333333333ULL) + ((x & 0xCCCCCCCCCCCCCCCCULL) >> 2);
-    x = (x & 0x0F0F0F0F0F0F0F0FULL) + ((x & 0xF0F0F0F0F0F0F0F0ULL) >> 4);
-    x *= 0x0101010101010101ULL;
-    value_ = x;
-  }
+#else  // c++17
 
-  std::size_t lo8() const {
-    return (std::size_t)(value_ & 0xFFU);
-  }
-  std::size_t lo16() const {
-    return (std::size_t)((value_ >> 8) & 0xFFU);
-  }
-  std::size_t lo24() const {
-    return (std::size_t)((value_ >> 16) & 0xFFU);
-  }
-  std::size_t lo32() const {
-    return (std::size_t)((value_ >> 24) & 0xFFU);
-  }
-  std::size_t lo40() const {
-    return (std::size_t)((value_ >> 32) & 0xFFU);
-  }
-  std::size_t lo48() const {
-    return (std::size_t)((value_ >> 40) & 0xFFU);
-  }
-  std::size_t lo56() const {
-    return (std::size_t)((value_ >> 48) & 0xFFU);
-  }
-  std::size_t lo64() const {
-    return (std::size_t)((value_ >> 56) & 0xFFU);
-  }
+ #ifdef __has_builtin
+  #define MARISA_HAS_BUILTIN(x) __has_builtin(x)
+ #else
+  #define MARISA_HAS_BUILTIN(x) 0
+ #endif
 
-  static std::size_t count(UInt64 x) {
- #if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
-    return std::popcount(x);
- #elif MARISA_HAS_BUILTIN(__builtin_popcountll)
-    static_assert(sizeof(x) == sizeof(unsigned long long),
-                  "__builtin_popcountll does not take 64-bit arg");
-    return __builtin_popcountll(x);
- #elif defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
-  #ifdef _MSC_VER
-    return __popcnt64(x);
-  #else   // _MSC_VER
-    return static_cast<std::size_t>(_mm_popcnt_u64(x));
-  #endif  // _MSC_VER
- #elif defined(MARISA_AARCH64)
-    // Byte-wise popcount followed by horizontal add.
-    return vaddv_u8(vcnt_u8(vcreate_u8(x)));
- #else   // defined(MARISA_AARCH64)
-    return PopCount(x).lo64();
- #endif  // defined(MARISA_AARCH64)
-  }
+ #if MARISA_WORD_SIZE == 64
 
- private:
-  UInt64 value_;
-};
+inline std::size_t popcount(UInt64 x) {
+  #if MARISA_HAS_BUILTIN(__builtin_popcountll)
+  static_assert(sizeof(x) == sizeof(unsigned long long),
+                "__builtin_popcountll does not take 64-bit arg");
+  return __builtin_popcountll(x);
+  #elif defined(MARISA_X64) && defined(MARISA_USE_POPCNT)
+   #ifdef _MSC_VER
+  return __popcnt64(x);
+   #else   // _MSC_VER
+  return static_cast<std::size_t>(_mm_popcnt_u64(x));
+   #endif  // _MSC_VER
+  #elif defined(MARISA_AARCH64)
+  // Byte-wise popcount followed by horizontal add.
+  return vaddv_u8(vcnt_u8(vcreate_u8(x)));
+  #else   // defined(MARISA_AARCH64)
+  x = (x & 0x5555555555555555ULL) + ((x & 0xAAAAAAAAAAAAAAAAULL) >> 1);
+  x = (x & 0x3333333333333333ULL) + ((x & 0xCCCCCCCCCCCCCCCCULL) >> 2);
+  x = (x & 0x0F0F0F0F0F0F0F0FULL) + ((x & 0xF0F0F0F0F0F0F0F0ULL) >> 4);
+  x *= 0x0101010101010101ULL;
+  return x >> 56;
+  #endif  // defined(MARISA_AARCH64)
+}
 
-#else  // MARISA_WORD_SIZE == 64
+ #else  // MARISA_WORD_SIZE == 64
 
-class PopCount {
- public:
-  explicit PopCount(UInt32 x) : value_() {
-    x = (x & 0x55555555U) + ((x & 0xAAAAAAAAU) >> 1);
-    x = (x & 0x33333333U) + ((x & 0xCCCCCCCCU) >> 2);
-    x = (x & 0x0F0F0F0FU) + ((x & 0xF0F0F0F0U) >> 4);
-    x *= 0x01010101U;
-    value_ = x;
-  }
+inline std::size_t popcount(UInt32 x) {
+  #if MARISA_HAS_BUILTIN(__builtin_popcount)
+  static_assert(sizeof(x) == sizeof(unsigned int),
+                "__builtin_popcount does not take 32-bit arg");
+  return __builtin_popcount(x);
+  #elif defined(MARISA_USE_POPCNT)
+   #ifdef _MSC_VER
+  return __popcnt(x);
+   #else   // _MSC_VER
+  return _mm_popcnt_u32(x);
+   #endif  // _MSC_VER
+  #else    // MARISA_USE_POPCNT
+  x = (x & 0x55555555U) + ((x & 0xAAAAAAAAU) >> 1);
+  x = (x & 0x33333333U) + ((x & 0xCCCCCCCCU) >> 2);
+  x = (x & 0x0F0F0F0FU) + ((x & 0xF0F0F0F0U) >> 4);
+  x *= 0x01010101U;
+  return x >> 24;
+  #endif   // MARISA_USE_POPCNT
+}
 
-  std::size_t lo8() const {
-    return value_ & 0xFFU;
-  }
-  std::size_t lo16() const {
-    return (value_ >> 8) & 0xFFU;
-  }
-  std::size_t lo24() const {
-    return (value_ >> 16) & 0xFFU;
-  }
-  std::size_t lo32() const {
-    return (value_ >> 24) & 0xFFU;
-  }
+ #endif  // MARISA_WORD_SIZE == 64
 
-  static std::size_t count(UInt32 x) {
- #if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
-    return std::popcount(x);
- #elif MARISA_HAS_BUILTIN(__builtin_popcount)
-    static_assert(sizeof(x) == sizeof(unsigned int),
-                  "__builtin_popcount does not take 32-bit arg");
-    return __builtin_popcount(x);
- #elif defined(MARISA_USE_POPCNT)
-  #ifdef _MSC_VER
-    return __popcnt(x);
-  #else   // _MSC_VER
-    return _mm_popcnt_u32(x);
-  #endif  // _MSC_VER
- #else    // MARISA_USE_POPCNT
-    return PopCount(x).lo32();
- #endif   // MARISA_USE_POPCNT
-  }
+ #undef MARISA_HAS_BUILTIN
 
- private:
-  UInt32 value_;
-};
-
-#endif  // MARISA_WORD_SIZE == 64
-
-#undef MARISA_HAS_BUILTIN
+#endif  // c++17
 
 }  // namespace vector
 }  // namespace grimoire

--- a/tests/vector-test.cc
+++ b/tests/vector-test.cc
@@ -13,78 +13,28 @@
 
 namespace {
 
+using marisa::grimoire::vector::popcount;
+
 std::random_device seed_gen;
 std::mt19937 random_engine(seed_gen());
 
 #if MARISA_WORD_SIZE == 64
-void TestPopCount() {
+void TestPopcount() {
   TEST_START();
 
-  {
-    marisa::grimoire::vector::PopCount count(0);
-    ASSERT(count.lo8() == 0);
-    ASSERT(count.lo16() == 0);
-    ASSERT(count.lo24() == 0);
-    ASSERT(count.lo32() == 0);
-    ASSERT(count.lo40() == 0);
-    ASSERT(count.lo48() == 0);
-    ASSERT(count.lo56() == 0);
-    ASSERT(count.lo64() == 0);
-  }
-
-  {
-    marisa::grimoire::vector::PopCount count(0xFFFFFFFFFFFFFFFFULL);
-    ASSERT(count.lo8() == 8);
-    ASSERT(count.lo16() == 16);
-    ASSERT(count.lo24() == 24);
-    ASSERT(count.lo32() == 32);
-    ASSERT(count.lo40() == 40);
-    ASSERT(count.lo48() == 48);
-    ASSERT(count.lo56() == 56);
-    ASSERT(count.lo64() == 64);
-  }
-
-  {
-    marisa::grimoire::vector::PopCount count(0xFF7F3F1F0F070301ULL);
-    ASSERT(count.lo8() == 1);
-    ASSERT(count.lo16() == 3);
-    ASSERT(count.lo24() == 6);
-    ASSERT(count.lo32() == 10);
-    ASSERT(count.lo40() == 15);
-    ASSERT(count.lo48() == 21);
-    ASSERT(count.lo56() == 28);
-    ASSERT(count.lo64() == 36);
-  }
+  ASSERT(popcount(0U) == 0);
+  ASSERT(popcount(~0ULL) == 64);
+  ASSERT(popcount(0xFF7F3F1F0F070301ULL) == 36);
 
   TEST_END();
 }
 #else  // MARISA_WORD_SIZE == 64
-void TestPopCount() {
+void TestPopcount() {
   TEST_START();
 
-  {
-    marisa::grimoire::vector::PopCount count(0);
-    ASSERT(count.lo8() == 0);
-    ASSERT(count.lo16() == 0);
-    ASSERT(count.lo24() == 0);
-    ASSERT(count.lo32() == 0);
-  }
-
-  {
-    marisa::grimoire::vector::PopCount count(0xFFFFFFFFU);
-    ASSERT(count.lo8() == 8);
-    ASSERT(count.lo16() == 16);
-    ASSERT(count.lo24() == 24);
-    ASSERT(count.lo32() == 32);
-  }
-
-  {
-    marisa::grimoire::vector::PopCount count(0xFF3F0F03U);
-    ASSERT(count.lo8() == 2);
-    ASSERT(count.lo16() == 6);
-    ASSERT(count.lo24() == 12);
-    ASSERT(count.lo32() == 20);
-  }
+  ASSERT(popcount(0U) == 0);
+  ASSERT(popcount(~0U) == 32);
+  ASSERT(popcount(0xFF3F0F03U) == 20);
 
   TEST_END();
 }
@@ -448,7 +398,7 @@ void TestBitVector() {
 }  // namespace
 
 int main() try {
-  TestPopCount();
+  TestPopcount();
   TestRankIndex();
 
   TestVector();


### PR DESCRIPTION
43ead6a (Optimize select_bit #52) removed the use of other PopCount member functions, so we don't need the class now.

https://github.com/s-yata/marisa-trie/commit/43ead6ac8a1d83d5f6196f58495249ea241aa9a0