### PR TITLE
CMake: Fix header install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,6 @@ target_include_directories(marisa
 set_target_properties(marisa PROPERTIES
   VERSION "${Marisa_VERSION}"
   SOVERSION "${Marisa_VERSION_MAJOR}"
-  PUBLIC_HEADER "${MARISA_HEADERS}"
 )
 configure_target_from_options(marisa)
 add_native_code(marisa)
@@ -247,13 +246,27 @@ if(BUILD_TESTING)
 endif()
 
 # Install configuration
+
+if(NOT DEFINED LIB_INSTALL_DIR)
+  set(LIB_INSTALL_DIR lib)
+endif()
+
+# We do not pass PUBLIC_HEADER because it doesn't respect subdirectories.
+# Instead, we install the headers manually via a second call to `install`.
 install(
   TARGETS marisa
   EXPORT MarisaTargets
-  PUBLIC_HEADER
   CONFIGURATIONS Release
-  DESTINATION include
+  DESTINATION ${LIB_INSTALL_DIR}
+  COMPONENT Library
 )
+install(
+  DIRECTORY include/
+  DESTINATION include
+  COMPONENT Library
+  FILES_MATCHING PATTERN "*.h"
+)
+
 if(ENABLE_TOOLS)
   install(
     TARGETS ${MARISA_TOOLS}
@@ -262,9 +275,6 @@ if(ENABLE_TOOLS)
   )
 endif()
 
-if(NOT DEFINED LIB_INSTALL_DIR)
-  set(LIB_INSTALL_DIR lib)
-endif()
 set(ConfigPackageLocation "${LIB_INSTALL_DIR}/cmake/Marisa")
 
 include(CMakePackageConfigHelpers)
@@ -287,6 +297,7 @@ install(EXPORT MarisaTargets
   FILE MarisaTargets.cmake
   NAMESPACE Marisa::
   DESTINATION ${ConfigPackageLocation}
+  COMPONENT Library
 )
 
 install(
@@ -295,4 +306,5 @@ install(
     "${CMAKE_CURRENT_BINARY_DIR}/Marisa/MarisaConfigVersion.cmake"
   DESTINATION
     ${ConfigPackageLocation}
+  COMPONENT Library
 )


### PR DESCRIPTION
Refs #86

```bash
sudo cmake --install build-rel
```

```
-- Install configuration: "Release"
-- Installing: /usr/local/lib/libmarisa.a
-- Up-to-date: /usr/local/include
-- Up-to-date: /usr/local/include/marisa
-- Up-to-date: /usr/local/include/marisa/keyset.h
-- Up-to-date: /usr/local/include/marisa/agent.h
-- Up-to-date: /usr/local/include/marisa/key.h
-- Up-to-date: /usr/local/include/marisa/base.h
-- Up-to-date: /usr/local/include/marisa/exception.h
-- Up-to-date: /usr/local/include/marisa/trie.h
-- Up-to-date: /usr/local/include/marisa/query.h
-- Up-to-date: /usr/local/include/marisa/stdio.h
-- Up-to-date: /usr/local/include/marisa/iostream.h
-- Installing: /usr/local/include/marisa.h
-- Installing: /usr/local/bin/marisa-build
-- Installing: /usr/local/bin/marisa-lookup
-- Installing: /usr/local/bin/marisa-reverse-lookup
-- Installing: /usr/local/bin/marisa-common-prefix-search
-- Installing: /usr/local/bin/marisa-predictive-search
-- Installing: /usr/local/bin/marisa-dump
-- Installing: /usr/local/bin/marisa-benchmark
-- Installing: /usr/local/lib/cmake/Marisa/MarisaTargets.cmake
-- Installing: /usr/local/lib/cmake/Marisa/MarisaTargets-release.cmake
-- Installing: /usr/local/lib/cmake/Marisa/MarisaConfig.cmake
-- Installing: /usr/local/lib/cmake/Marisa/MarisaConfigVersion.cmake
```