### PR TITLE
CMake: Bring back marisa.pc.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,3 +308,6 @@ install(
     ${ConfigPackageLocation}
   COMPONENT Library
 )
+
+configure_file(marisa.pc.in ${CMAKE_CURRENT_BINARY_DIR}/marisa.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/marisa.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)

--- a/marisa.pc.in
+++ b/marisa.pc.in
@@ -1,0 +1,8 @@
+libdir=@CMAKE_INSTALL_PREFIX@/@LIB_INSTALL_DIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include
+
+Name: Marisa
+Description: Matching Algorithm with Recursively Implemented StorAge
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmarisa


### PR DESCRIPTION
It was present in 0.2.7 but was removed during autoconf -> cmake migration.