### PR TITLE
cmake: force to build a static library from cmdopt.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ set(MARISA_TOOLS
   marisa-benchmark
 )
 if(ENABLE_TOOLS)
-  add_library(cmdopt tools/cmdopt.h tools/cmdopt.cc)
+  add_library(cmdopt STATIC tools/cmdopt.h tools/cmdopt.cc)
   target_include_directories(cmdopt PUBLIC tools)
 
   foreach(_tool ${MARISA_TOOLS})


### PR DESCRIPTION
If STATIC is not specified, in case of BUILD_SHARED_LIBS=ON, binaries are linked to cmdopt.so but it is not installed.
This causes an error as follows:

marisa-build: error while loading shared libraries: libcmdopt.so: cannot open shared object file: No such file or directory