### PR TITLE
State: Use `std::vector`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ add_library(marisa
   lib/marisa/grimoire/vector/flat-vector.h
   lib/marisa/grimoire/vector/pop-count.h
   lib/marisa/grimoire/vector/rank-index.h
+  lib/marisa/grimoire/vector/rethrowing-std-vector.h
   lib/marisa/grimoire/vector/vector.h
   lib/marisa/keyset.cc
   lib/marisa/trie.cc

--- a/include/marisa/exception.h
+++ b/include/marisa/exception.h
@@ -18,7 +18,7 @@ class Exception : public std::exception {
       : std::exception(), filename_(filename), line_(line),
         error_code_(error_code), error_message_(error_message) {}
   Exception(const Exception &ex) noexcept = default;
-  virtual ~Exception() noexcept;
+  ~Exception() noexcept override;
 
   Exception &operator=(const Exception &rhs) noexcept;
 
@@ -35,7 +35,7 @@ class Exception : public std::exception {
     return error_message_;
   }
 
-  virtual const char *what() const noexcept {
+  const char *what() const noexcept override {
     return error_message_;
   }
 
@@ -69,6 +69,26 @@ class Exception : public std::exception {
  #define MARISA_DEBUG_IF(cond, error_code) MARISA_THROW_IF(cond, error_code)
 #else
  #define MARISA_DEBUG_IF(cond, error_code)
+#endif
+
+#ifndef MARISA_USE_EXCEPTIONS
+ #if defined(__GNUC__) && !defined(__EXCEPTIONS)
+  #define MARISA_USE_EXCEPTIONS 0
+ #elif defined(__clang__) && !defined(__cpp_exceptions)
+  #define MARISA_USE_EXCEPTIONS 0
+ #elif defined(_MSC_VER) && !_HAS_EXCEPTIONS
+  #define MARISA_USE_EXCEPTIONS 0
+ #else
+  #define MARISA_USE_EXCEPTIONS 1
+ #endif
+#endif
+
+#if MARISA_USE_EXCEPTIONS
+ #define MARISA_TRY      try
+ #define MARISA_CATCH(x) catch (x)
+#else
+ #define MARISA_TRY      if (true)
+ #define MARISA_CATCH(x) if (false)
 #endif
 
 }  // namespace marisa

--- a/lib/marisa/agent.cc
+++ b/lib/marisa/agent.cc
@@ -18,7 +18,7 @@ void UpdateAgentAfterCopyingState(const grimoire::trie::State &state,
       // In states corresponding to predictive_search, the agent's
       // key points into the state key buffer. We need to repoint
       // after copying the state.
-      agent.set_key(state.key_buf().begin(), state.key_buf().size());
+      agent.set_key(state.key_buf().data(), state.key_buf().size());
       break;
     default:
       // In other states, they key is either null, or points to the

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -77,7 +77,7 @@ void LoudsTrie::reverse_lookup(Agent &agent) const {
 
   state.set_node_id(terminal_flags_.select1(agent.query().id()));
   if (state.node_id() == 0) {
-    agent.set_key(state.key_buf().begin(), state.key_buf().size());
+    agent.set_key(state.key_buf().data(), state.key_buf().size());
     agent.set_key(agent.query().id());
     return;
   }
@@ -93,7 +93,7 @@ void LoudsTrie::reverse_lookup(Agent &agent) const {
 
     if (state.node_id() <= num_l1_nodes_) {
       std::reverse(state.key_buf().begin(), state.key_buf().end());
-      agent.set_key(state.key_buf().begin(), state.key_buf().size());
+      agent.set_key(state.key_buf().data(), state.key_buf().size());
       agent.set_key(agent.query().id());
       return;
     }
@@ -156,7 +156,7 @@ bool LoudsTrie::predictive_search(Agent &agent) const {
     state.set_history_pos(1);
 
     if (terminal_flags_[state.node_id()]) {
-      agent.set_key(state.key_buf().begin(), state.key_buf().size());
+      agent.set_key(state.key_buf().data(), state.key_buf().size());
       agent.set_key(terminal_flags_.rank1(state.node_id()));
       return true;
     }
@@ -190,7 +190,7 @@ bool LoudsTrie::predictive_search(Agent &agent) const {
         } else {
           next.set_key_id(next.key_id() + 1);
         }
-        agent.set_key(state.key_buf().begin(), state.key_buf().size());
+        agent.set_key(state.key_buf().data(), state.key_buf().size());
         agent.set_key(next.key_id());
         return true;
       }

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -88,7 +88,7 @@ void LoudsTrie::reverse_lookup(Agent &agent) const {
       std::reverse(state.key_buf().begin() + prev_key_pos,
                    state.key_buf().end());
     } else {
-      state.key_buf().push_back((char)bases_[state.node_id()]);
+      state.key_buf().push_back(static_cast<char>(bases_[state.node_id()]));
     }
 
     if (state.node_id() <= num_l1_nodes_) {
@@ -180,7 +180,7 @@ bool LoudsTrie::predictive_search(Agent &agent) const {
         next.set_link_id(update_link_id(next.link_id(), next.node_id()));
         restore(agent, get_link(next.node_id(), next.link_id()));
       } else {
-        state.key_buf().push_back((char)bases_[next.node_id()]);
+        state.key_buf().push_back(static_cast<char>(bases_[next.node_id()]));
       }
       next.set_key_pos(state.key_buf().size());
 
@@ -682,7 +682,7 @@ bool LoudsTrie::predictive_find_child(Agent &agent) const {
       }
     } else if (bases_[state.node_id()] ==
                (UInt8)agent.query()[state.query_pos()]) {
-      state.key_buf().push_back((char)bases_[state.node_id()]);
+      state.key_buf().push_back(static_cast<char>(bases_[state.node_id()]));
       state.set_query_pos(state.query_pos() + 1);
       return true;
     }
@@ -739,7 +739,7 @@ void LoudsTrie::restore_(Agent &agent, std::size_t node_id) const {
     if (link_flags_[node_id]) {
       restore(agent, get_link(node_id));
     } else {
-      state.key_buf().push_back((char)bases_[node_id]);
+      state.key_buf().push_back(static_cast<char>(bases_[node_id]));
     }
 
     if (node_id <= num_l1_nodes_) {
@@ -830,7 +830,7 @@ bool LoudsTrie::prefix_match_(Agent &agent, std::size_t node_id) const {
           return false;
         }
       } else if (bases_[node_id] == (UInt8)agent.query()[state.query_pos()]) {
-        state.key_buf().push_back((char)bases_[node_id]);
+        state.key_buf().push_back(static_cast<char>(bases_[node_id]));
         state.set_query_pos(state.query_pos() + 1);
       } else {
         return false;

--- a/lib/marisa/grimoire/trie/state.h
+++ b/lib/marisa/grimoire/trie/state.h
@@ -1,9 +1,8 @@
 #ifndef MARISA_GRIMOIRE_TRIE_STATE_H_
 #define MARISA_GRIMOIRE_TRIE_STATE_H_
 
-#include <vector>
-
 #include "marisa/grimoire/trie/history.h"
+#include "marisa/grimoire/vector/rethrowing-std-vector.h"
 
 namespace marisa::grimoire::trie {
 
@@ -55,17 +54,18 @@ class State {
     return status_code_;
   }
 
-  const std::vector<char> &key_buf() const {
+  const marisa::grimoire::vector::RethrowingStdVector<char> &key_buf() const {
     return key_buf_;
   }
-  const std::vector<History> &history() const {
+  const marisa::grimoire::vector::RethrowingStdVector<History> &history()
+      const {
     return history_;
   }
 
-  std::vector<char> &key_buf() {
+  marisa::grimoire::vector::RethrowingStdVector<char> &key_buf() {
     return key_buf_;
   }
-  std::vector<History> &history() {
+  marisa::grimoire::vector::RethrowingStdVector<History> &history() {
     return history_;
   }
 
@@ -100,8 +100,8 @@ class State {
   }
 
  private:
-  std::vector<char> key_buf_;
-  std::vector<History> history_;
+  marisa::grimoire::vector::RethrowingStdVector<char> key_buf_;
+  marisa::grimoire::vector::RethrowingStdVector<History> history_;
   UInt32 node_id_ = 0;
   UInt32 query_pos_ = 0;
   UInt32 history_pos_ = 0;

--- a/lib/marisa/grimoire/trie/state.h
+++ b/lib/marisa/grimoire/trie/state.h
@@ -1,8 +1,9 @@
 #ifndef MARISA_GRIMOIRE_TRIE_STATE_H_
 #define MARISA_GRIMOIRE_TRIE_STATE_H_
 
+#include <vector>
+
 #include "marisa/grimoire/trie/history.h"
-#include "marisa/grimoire/vector.h"
 
 namespace marisa::grimoire::trie {
 
@@ -54,17 +55,17 @@ class State {
     return status_code_;
   }
 
-  const Vector<char> &key_buf() const {
+  const std::vector<char> &key_buf() const {
     return key_buf_;
   }
-  const Vector<History> &history() const {
+  const std::vector<History> &history() const {
     return history_;
   }
 
-  Vector<char> &key_buf() {
+  std::vector<char> &key_buf() {
     return key_buf_;
   }
-  Vector<History> &history() {
+  std::vector<History> &history() {
     return history_;
   }
 
@@ -99,8 +100,8 @@ class State {
   }
 
  private:
-  Vector<char> key_buf_;
-  Vector<History> history_;
+  std::vector<char> key_buf_;
+  std::vector<History> history_;
   UInt32 node_id_ = 0;
   UInt32 query_pos_ = 0;
   UInt32 history_pos_ = 0;

--- a/lib/marisa/grimoire/vector/rethrowing-std-vector.h
+++ b/lib/marisa/grimoire/vector/rethrowing-std-vector.h
@@ -1,0 +1,151 @@
+#ifndef MARISA_GRIMOIRE_VECTOR_RETHROWING_STD_VECTOR_H_
+#define MARISA_GRIMOIRE_VECTOR_RETHROWING_STD_VECTOR_H_
+
+#include <new>
+#include <stdexcept>
+#include <vector>
+
+#include "marisa/base.h"
+
+namespace marisa::grimoire::vector {
+
+// Wraps an std::vector and rethrows all exceptions as marisa::Exception.
+template <typename T>
+class RethrowingStdVector {
+ public:
+  using value_type = typename std::vector<T>::value_type;
+  using allocator_type = typename std::vector<T>::allocator_type;
+  using size_type = typename std::vector<T>::size_type;
+  using difference_type = typename std::vector<T>::difference_type;
+  using reference = typename std::vector<T>::reference;
+  using const_reference = typename std::vector<T>::const_reference;
+  using pointer = typename std::vector<T>::pointer;
+  using const_pointer = typename std::vector<T>::const_pointer;
+  using iterator = typename std::vector<T>::iterator;
+  using const_iterator = typename std::vector<T>::const_iterator;
+  using reverse_iterator = typename std::vector<T>::reverse_iterator;
+  using const_reverse_iterator =
+      typename std::vector<T>::const_reverse_iterator;
+
+  RethrowingStdVector() = default;
+  RethrowingStdVector(const RethrowingStdVector &other) {
+    MARISA_TRY {
+      vector_ = other.vector_;
+    }
+    MARISA_CATCH(const std::bad_alloc &e) {
+      MARISA_THROW(MARISA_SIZE_ERROR, "std::bad_alloc");
+    }
+  }
+  RethrowingStdVector &operator=(const RethrowingStdVector &other) {
+    MARISA_TRY {
+      vector_ = other.vector_;
+    }
+    MARISA_CATCH(const std::bad_alloc &e) {
+      MARISA_THROW(MARISA_SIZE_ERROR, "std::bad_alloc");
+    }
+  }
+  RethrowingStdVector(RethrowingStdVector &&other) noexcept = default;
+  RethrowingStdVector &operator=(RethrowingStdVector &&other) noexcept =
+      default;
+
+  bool empty() const noexcept {
+    return vector_.empty();
+  }
+  size_type size() const noexcept {
+    return vector_.size();
+  }
+  reference operator[](size_type pos) {
+    MARISA_DEBUG_IF(empty(), MARISA_BOUND_ERROR);
+    MARISA_DEBUG_IF(pos >= size(), MARISA_BOUND_ERROR);
+    return vector_[pos];
+  }
+  const_reference operator[](size_type pos) const {
+    MARISA_DEBUG_IF(empty(), MARISA_BOUND_ERROR);
+    MARISA_DEBUG_IF(pos >= size(), MARISA_BOUND_ERROR);
+    return vector_[pos];
+  }
+  reference front() {
+    MARISA_DEBUG_IF(empty(), MARISA_BOUND_ERROR);
+    return vector_.front();
+  }
+  const_reference front() const {
+    MARISA_DEBUG_IF(empty(), MARISA_BOUND_ERROR);
+    return vector_.front();
+  }
+  reference back() {
+    MARISA_DEBUG_IF(empty(), MARISA_BOUND_ERROR);
+    return vector_.back();
+  }
+  const_reference back() const {
+    MARISA_DEBUG_IF(empty(), MARISA_BOUND_ERROR);
+    return vector_.back();
+  }
+  T *data() noexcept {
+    return vector_.data();
+  }
+  const T *data() const noexcept {
+    return vector_.data();
+  }
+
+  iterator begin() noexcept {
+    return vector_.begin();
+  }
+  const_iterator begin() const noexcept {
+    return vector_.begin();
+  }
+  const_iterator cbegin() const noexcept {
+    return vector_.cbegin();
+  }
+  iterator end() noexcept {
+    return vector_.end();
+  }
+  const_iterator end() const noexcept {
+    return vector_.end();
+  }
+  const_iterator cend() const noexcept {
+    return vector_.cend();
+  }
+
+  void push_back(const T &value) {
+    MARISA_TRY {
+      vector_.push_back(value);
+    }
+    MARISA_CATCH(const std::length_error &e) {
+      MARISA_THROW(MARISA_SIZE_ERROR, "std::length_error");
+    }
+    MARISA_CATCH(const std::bad_alloc &e) {
+      MARISA_THROW(MARISA_MEMORY_ERROR, "std::bad_alloc");
+    }
+  }
+
+  void reserve(size_type new_cap) {
+    MARISA_TRY {
+      vector_.reserve(new_cap);
+    }
+    MARISA_CATCH(const std::length_error &e) {
+      MARISA_THROW(MARISA_SIZE_ERROR, "std::length_error");
+    }
+    MARISA_CATCH(const std::bad_alloc &e) {
+      MARISA_THROW(MARISA_MEMORY_ERROR, "std::bad_alloc");
+    }
+  }
+
+  void resize(size_type count) {
+    MARISA_TRY {
+      vector_.resize(count);
+    }
+    MARISA_CATCH(const std::length_error &e) {
+      MARISA_THROW(MARISA_SIZE_ERROR, "std::length_error");
+    }
+    MARISA_CATCH(const std::bad_alloc &e) {
+      MARISA_THROW(MARISA_MEMORY_ERROR, "std::bad_alloc");
+    }
+  }
+
+ private:
+  std::vector<T> vector_;
+};
+
+}  // namespace marisa::grimoire::vector
+
+#endif  // MARISA_GRIMOIRE_VECTOR_RETHROWING_STD_VECTOR_H_


### PR DESCRIPTION
The vectors in `State` are never memory-mapped, so we can use `std::vector` instead of Marisa's vector.

`std::vector` is smaller in size (24 bytes vs 32 bytes).

This reduces `State` size from 80 bytes to 64 bytes, making it fit into a single cache line.

Benchmark on my machine shows a tiny improvement on a large file (best run of 3, so could just be noise):

Before:

```
Number of tries: 1 - 5
TAIL mode: Text mode
Node order: Descending weight order
Cache level: Normal cache
Number of keys: 100000
Total length: 2552180
------+----------+--------+--------+--------+--------+--------
#tries       size    build   lookup  reverse   prefix  predict
                                      lookup   search   search
          [bytes]    [K/s]    [K/s]    [K/s]    [K/s]    [K/s]
------+----------+--------+--------+--------+--------+--------
     1    2671808  2103.71  3719.41  4865.23  3502.50   226.75
     2    2623280  1718.33  2442.30  3081.38  2328.61    82.26
     3    2589952  1349.84  1763.61  2414.41  1780.18    50.49
     4    2560184  1160.51  1467.46  1991.91  1430.51    37.06
     5    2533704  1011.27  1239.13  1674.87  1213.36    29.25
------+----------+--------+--------+--------+--------+--------
```

After:
```
------+----------+--------+--------+--------+--------+--------
#tries       size    build   lookup  reverse   prefix  predict
                                      lookup   search   search
          [bytes]    [K/s]    [K/s]    [K/s]    [K/s]    [K/s]
------+----------+--------+--------+--------+--------+--------
     1    2671808  2089.91  3801.27  4954.66  3593.12   231.46
     2    2623280  1715.00  2398.54  3184.51  2322.39    83.26
     3    2589952  1360.84  1821.86  2412.37  1742.92    51.08
     4    2560184  1153.80  1468.41  1966.65  1424.16    37.24
     5    2533704  1009.94  1230.84  1680.45  1209.50    29.56
```