### PR TITLE
Remove clang warnings

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -35,11 +35,11 @@ typedef uint64_t marisa_uint64;
 
 // #define MARISA_WORD_SIZE  (sizeof(void *) * 8)
 
-#define MARISA_UINT8_MAX  ((marisa_uint8) ~(marisa_uint8)0)
-#define MARISA_UINT16_MAX ((marisa_uint16) ~(marisa_uint16)0)
-#define MARISA_UINT32_MAX ((marisa_uint32) ~(marisa_uint32)0)
-#define MARISA_UINT64_MAX ((marisa_uint64) ~(marisa_uint64)0)
-#define MARISA_SIZE_MAX   ((size_t)~(size_t)0)
+#define MARISA_UINT8_MAX  UINT8_MAX
+#define MARISA_UINT16_MAX UINT16_MAX
+#define MARISA_UINT32_MAX UINT32_MAX
+#define MARISA_UINT64_MAX UINT64_MAX
+#define MARISA_SIZE_MAX   SIZE_MAX
 
 #define MARISA_INVALID_LINK_ID MARISA_UINT32_MAX
 #define MARISA_INVALID_KEY_ID  MARISA_UINT32_MAX

--- a/include/marisa/key.h
+++ b/include/marisa/key.h
@@ -29,17 +29,17 @@ class Key {
     }
     MARISA_DEBUG_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
     ptr_ = str;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
   void set_str(const char *ptr, std::size_t length) {
     MARISA_DEBUG_IF((ptr == nullptr) && (length != 0), MARISA_NULL_ERROR);
     MARISA_DEBUG_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
     ptr_ = ptr;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
   void set_id(std::size_t id) {
     MARISA_DEBUG_IF(id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    union_.id = (UInt32)id;
+    union_.id = static_cast<UInt32>(id);
   }
   void set_weight(float weight) {
     union_.weight = weight;

--- a/lib/marisa/grimoire/algorithm/sort.h
+++ b/lib/marisa/grimoire/algorithm/sort.h
@@ -14,9 +14,7 @@ template <typename T>
 int get_label(const T &unit, std::size_t depth) {
   MARISA_DEBUG_IF(depth > unit.length(), MARISA_BOUND_ERROR);
 
-  return (depth < unit.length())
-             ? static_cast<int>(static_cast<UInt8>(unit[depth]))
-             : -1;
+  return (depth < unit.length()) ? int{static_cast<UInt8>(unit[depth])} : -1;
 }
 
 template <typename T>

--- a/lib/marisa/grimoire/algorithm/sort.h
+++ b/lib/marisa/grimoire/algorithm/sort.h
@@ -14,7 +14,9 @@ template <typename T>
 int get_label(const T &unit, std::size_t depth) {
   MARISA_DEBUG_IF(depth > unit.length(), MARISA_BOUND_ERROR);
 
-  return (depth < unit.length()) ? (int)(UInt8)unit[depth] : -1;
+  return (depth < unit.length())
+             ? static_cast<int>(static_cast<UInt8>(unit[depth]))
+             : -1;
 }
 
 template <typename T>
@@ -44,7 +46,7 @@ int compare(const T &lhs, const T &rhs, std::size_t depth) {
       return 1;
     }
     if (lhs[i] != rhs[i]) {
-      return (UInt8)lhs[i] - (UInt8)rhs[i];
+      return static_cast<UInt8>(lhs[i]) - static_cast<UInt8>(rhs[i]);
     }
   }
   if (lhs.length() == rhs.length()) {

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -115,7 +115,7 @@ void Mapper::open_(const char *filename, int flags) {
   DWORD size_high, size_low;
   size_low = ::GetFileSize(file_, &size_high);
   MARISA_THROW_IF(size_low == INVALID_FILE_SIZE, MARISA_IO_ERROR);
-  size_ = ((std::size_t)size_high << 32) | size_low;
+  size_ = (static_cast<std::size_t>(size_high) << 32) | size_low;
 
   map_ = ::CreateFileMapping(file_, nullptr, PAGE_READONLY, 0, 0, nullptr);
   MARISA_THROW_IF(map_ == nullptr, MARISA_IO_ERROR);
@@ -140,8 +140,9 @@ void Mapper::open_(const char *filename, int flags) {
 
   struct stat st;
   MARISA_THROW_IF(::fstat(fd_, &st) != 0, MARISA_IO_ERROR);
-  MARISA_THROW_IF((UInt64)st.st_size > MARISA_SIZE_MAX, MARISA_SIZE_ERROR);
-  size_ = (std::size_t)st.st_size;
+  MARISA_THROW_IF(static_cast<UInt64>(st.st_size) > MARISA_SIZE_MAX,
+                  MARISA_SIZE_ERROR);
+  size_ = static_cast<std::size_t>(st.st_size);
 
   int map_flags = MAP_SHARED;
  #if defined(MAP_POPULATE)

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -115,7 +115,7 @@ void Mapper::open_(const char *filename, int flags) {
   DWORD size_high, size_low;
   size_low = ::GetFileSize(file_, &size_high);
   MARISA_THROW_IF(size_low == INVALID_FILE_SIZE, MARISA_IO_ERROR);
-  size_ = (static_cast<std::size_t>(size_high) << 32) | size_low;
+  size_ = (std::size_t{size_high} << 32) | size_low;
 
   map_ = ::CreateFileMapping(file_, nullptr, PAGE_READONLY, 0, 0, nullptr);
   MARISA_THROW_IF(map_ == nullptr, MARISA_IO_ERROR);

--- a/lib/marisa/grimoire/trie/cache.h
+++ b/lib/marisa/grimoire/trie/cache.h
@@ -15,18 +15,18 @@ class Cache {
 
   void set_parent(std::size_t parent) {
     MARISA_DEBUG_IF(parent > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    parent_ = (UInt32)parent;
+    parent_ = static_cast<UInt32>(parent);
   }
   void set_child(std::size_t child) {
     MARISA_DEBUG_IF(child > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    child_ = (UInt32)child;
+    child_ = static_cast<UInt32>(child);
   }
   void set_base(UInt8 base) {
     union_.link = (union_.link & ~0xFFU) | base;
   }
   void set_extra(std::size_t extra) {
     MARISA_DEBUG_IF(extra > (MARISA_UINT32_MAX >> 8), MARISA_SIZE_ERROR);
-    union_.link = (UInt32)((union_.link & 0xFFU) | (extra << 8));
+    union_.link = static_cast<UInt32>((union_.link & 0xFFU) | (extra << 8));
   }
   void set_weight(float weight) {
     union_.weight = weight;
@@ -39,13 +39,13 @@ class Cache {
     return child_;
   }
   UInt8 base() const {
-    return (UInt8)(union_.link & 0xFFU);
+    return static_cast<UInt8>(union_.link & 0xFFU);
   }
   std::size_t extra() const {
     return union_.link >> 8;
   }
   char label() const {
-    return (char)base();
+    return static_cast<char>(base());
   }
   std::size_t link() const {
     return union_.link;

--- a/lib/marisa/grimoire/trie/config.h
+++ b/lib/marisa/grimoire/trie/config.h
@@ -19,7 +19,7 @@ class Config {
   }
 
   int flags() const {
-    return (int)num_tries_ | tail_mode_ | node_order_;
+    return static_cast<int>(num_tries_) | tail_mode_ | node_order_;
   }
 
   std::size_t num_tries() const {

--- a/lib/marisa/grimoire/trie/entry.h
+++ b/lib/marisa/grimoire/trie/entry.h
@@ -20,11 +20,11 @@ class Entry {
     MARISA_DEBUG_IF((ptr == nullptr) && (length != 0), MARISA_NULL_ERROR);
     MARISA_DEBUG_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
     ptr_ = ptr + length - 1;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
   void set_id(std::size_t id) {
     MARISA_DEBUG_IF(id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    id_ = (UInt32)id;
+    id_ = static_cast<UInt32>(id);
   }
 
   const char *ptr() const {
@@ -45,7 +45,7 @@ class Entry {
           return true;
         }
         if (lhs[i] != rhs[i]) {
-          return (UInt8)lhs[i] > (UInt8)rhs[i];
+          return static_cast<UInt8>(lhs[i]) > static_cast<UInt8>(rhs[i]);
         }
       }
       return lhs.length() > rhs.length();

--- a/lib/marisa/grimoire/trie/history.h
+++ b/lib/marisa/grimoire/trie/history.h
@@ -11,23 +11,23 @@ class History {
 
   void set_node_id(std::size_t node_id) {
     MARISA_DEBUG_IF(node_id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    node_id_ = (UInt32)node_id;
+    node_id_ = static_cast<UInt32>(node_id);
   }
   void set_louds_pos(std::size_t louds_pos) {
     MARISA_DEBUG_IF(louds_pos > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    louds_pos_ = (UInt32)louds_pos;
+    louds_pos_ = static_cast<UInt32>(louds_pos);
   }
   void set_key_pos(std::size_t key_pos) {
     MARISA_DEBUG_IF(key_pos > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    key_pos_ = (UInt32)key_pos;
+    key_pos_ = static_cast<UInt32>(key_pos);
   }
   void set_link_id(std::size_t link_id) {
     MARISA_DEBUG_IF(link_id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    link_id_ = (UInt32)link_id;
+    link_id_ = static_cast<UInt32>(link_id);
   }
   void set_key_id(std::size_t key_id) {
     MARISA_DEBUG_IF(key_id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    key_id_ = (UInt32)key_id;
+    key_id_ = static_cast<UInt32>(key_id);
   }
 
   std::size_t node_id() const {

--- a/lib/marisa/grimoire/trie/key.h
+++ b/lib/marisa/grimoire/trie/key.h
@@ -21,25 +21,25 @@ class Key {
     MARISA_DEBUG_IF(length > length_, MARISA_BOUND_ERROR);
     MARISA_DEBUG_IF(pos > (length_ - length), MARISA_BOUND_ERROR);
     ptr_ += pos;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
 
   void set_str(const char *ptr, std::size_t length) {
     MARISA_DEBUG_IF((ptr == nullptr) && (length != 0), MARISA_NULL_ERROR);
     MARISA_DEBUG_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
     ptr_ = ptr;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
   void set_weight(float weight) {
     union_.weight = weight;
   }
   void set_terminal(std::size_t terminal) {
     MARISA_DEBUG_IF(terminal > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    union_.terminal = (UInt32)terminal;
+    union_.terminal = static_cast<UInt32>(terminal);
   }
   void set_id(std::size_t id) {
     MARISA_DEBUG_IF(id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    id_ = (UInt32)id;
+    id_ = static_cast<UInt32>(id);
   }
 
   const char *ptr() const {
@@ -90,7 +90,7 @@ inline bool operator<(const Key &lhs, const Key &rhs) {
       return false;
     }
     if (lhs[i] != rhs[i]) {
-      return (UInt8)lhs[i] < (UInt8)rhs[i];
+      return static_cast<UInt8>(lhs[i]) < static_cast<UInt8>(rhs[i]);
     }
   }
   return lhs.length() < rhs.length();
@@ -116,25 +116,25 @@ class ReverseKey {
     MARISA_DEBUG_IF(length > length_, MARISA_BOUND_ERROR);
     MARISA_DEBUG_IF(pos > (length_ - length), MARISA_BOUND_ERROR);
     ptr_ -= pos;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
 
   void set_str(const char *ptr, std::size_t length) {
     MARISA_DEBUG_IF((ptr == nullptr) && (length != 0), MARISA_NULL_ERROR);
     MARISA_DEBUG_IF(length > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
     ptr_ = ptr + length;
-    length_ = (UInt32)length;
+    length_ = static_cast<UInt32>(length);
   }
   void set_weight(float weight) {
     union_.weight = weight;
   }
   void set_terminal(std::size_t terminal) {
     MARISA_DEBUG_IF(terminal > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    union_.terminal = (UInt32)terminal;
+    union_.terminal = static_cast<UInt32>(terminal);
   }
   void set_id(std::size_t id) {
     MARISA_DEBUG_IF(id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    id_ = (UInt32)id;
+    id_ = static_cast<UInt32>(id);
   }
 
   const char *ptr() const {
@@ -185,7 +185,7 @@ inline bool operator<(const ReverseKey &lhs, const ReverseKey &rhs) {
       return false;
     }
     if (lhs[i] != rhs[i]) {
-      return (UInt8)lhs[i] < (UInt8)rhs[i];
+      return static_cast<UInt8>(lhs[i]) < static_cast<UInt8>(rhs[i]);
     }
   }
   return lhs.length() < rhs.length();

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -261,7 +261,7 @@ void LoudsTrie::build_(Keyset &keyset, const Config &config) {
   MARISA_THROW_IF(!pairs, MARISA_MEMORY_ERROR);
   for (std::size_t i = 0; i < pairs_size; ++i) {
     pairs[i].first = terminals[i];
-    pairs[i].second = (UInt32)i;
+    pairs[i].second = static_cast<UInt32>(i);
   }
   terminals.clear();
   std::sort(pairs.get(), pairs.get() + pairs_size);
@@ -313,7 +313,7 @@ void LoudsTrie::build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
     while (!link_flags_[node_id]) {
       ++node_id;
     }
-    bases_[node_id] = (UInt8)(next_terminals[i] % 256);
+    bases_[node_id] = static_cast<UInt8>(next_terminals[i] % 256);
     next_terminals[i] /= 256;
     ++node_id;
   }
@@ -362,15 +362,16 @@ void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
     double weight = keys[range.begin()].weight();
     for (std::size_t i = range.begin() + 1; i < range.end(); ++i) {
       if (keys[i - 1][range.key_pos()] != keys[i][range.key_pos()]) {
-        w_ranges.push_back(make_weighted_range(range.begin(), i,
-                                               range.key_pos(), (float)weight));
+        w_ranges.push_back(make_weighted_range(
+            range.begin(), i, range.key_pos(), static_cast<float>(weight)));
         range.set_begin(i);
         weight = 0.0;
       }
       weight += keys[i].weight();
     }
     w_ranges.push_back(make_weighted_range(range.begin(), range.end(),
-                                           range.key_pos(), (float)weight));
+                                           range.key_pos(),
+                                           static_cast<float>(weight)));
     if (config.node_order() == MARISA_WEIGHT_ORDER) {
       std::stable_sort(w_ranges.begin(), w_ranges.end(),
                        std::greater<WeightedRange>());
@@ -477,7 +478,7 @@ void LoudsTrie::build_terminals(const Vector<T> &keys,
   Vector<UInt32> temp;
   temp.resize(keys.size());
   for (std::size_t i = 0; i < keys.size(); ++i) {
-    temp[keys[i].id()] = (UInt32)keys[i].terminal();
+    temp[keys[i].id()] = static_cast<UInt32>(keys[i].terminal());
   }
   terminals->swap(temp);
 }
@@ -555,7 +556,7 @@ void LoudsTrie::map_(Mapper &mapper) {
   {
     UInt32 temp_config_flags;
     mapper.map(&temp_config_flags);
-    config_.parse((int)temp_config_flags);
+    config_.parse(static_cast<int>(temp_config_flags));
   }
 }
 
@@ -581,7 +582,7 @@ void LoudsTrie::read_(Reader &reader) {
   {
     UInt32 temp_config_flags;
     reader.read(&temp_config_flags);
-    config_.parse((int)temp_config_flags);
+    config_.parse(static_cast<int>(temp_config_flags));
   }
 }
 
@@ -596,8 +597,8 @@ void LoudsTrie::write_(Writer &writer) const {
     next_trie_->write_(writer);
   }
   cache_.write(writer);
-  writer.write((UInt32)num_l1_nodes_);
-  writer.write((UInt32)config_.flags());
+  writer.write(static_cast<UInt32>(num_l1_nodes_));
+  writer.write(static_cast<UInt32>(config_.flags()));
 }
 
 bool LoudsTrie::find_child(Agent &agent) const {
@@ -635,7 +636,7 @@ bool LoudsTrie::find_child(Agent &agent) const {
         return false;
       }
     } else if (bases_[state.node_id()] ==
-               (UInt8)agent.query()[state.query_pos()]) {
+               static_cast<UInt8>(agent.query()[state.query_pos()])) {
       state.set_query_pos(state.query_pos() + 1);
       return true;
     }
@@ -681,7 +682,7 @@ bool LoudsTrie::predictive_find_child(Agent &agent) const {
         return false;
       }
     } else if (bases_[state.node_id()] ==
-               (UInt8)agent.query()[state.query_pos()]) {
+               static_cast<UInt8>(agent.query()[state.query_pos()])) {
       state.key_buf().push_back(static_cast<char>(bases_[state.node_id()]));
       state.set_query_pos(state.query_pos() + 1);
       return true;
@@ -785,7 +786,8 @@ bool LoudsTrie::match_(Agent &agent, std::size_t node_id) const {
       } else if (!tail_.match(agent, get_link(node_id))) {
         return false;
       }
-    } else if (bases_[node_id] == (UInt8)agent.query()[state.query_pos()]) {
+    } else if (bases_[node_id] ==
+               static_cast<UInt8>(agent.query()[state.query_pos()])) {
       state.set_query_pos(state.query_pos() + 1);
     } else {
       return false;
@@ -829,7 +831,8 @@ bool LoudsTrie::prefix_match_(Agent &agent, std::size_t node_id) const {
         if (!prefix_match(agent, get_link(node_id))) {
           return false;
         }
-      } else if (bases_[node_id] == (UInt8)agent.query()[state.query_pos()]) {
+      } else if (bases_[node_id] ==
+                 static_cast<UInt8>(agent.query()[state.query_pos()])) {
         state.key_buf().push_back(static_cast<char>(bases_[node_id]));
         state.set_query_pos(state.query_pos() + 1);
       } else {
@@ -850,7 +853,7 @@ bool LoudsTrie::prefix_match_(Agent &agent, std::size_t node_id) const {
 }
 
 std::size_t LoudsTrie::get_cache_id(std::size_t node_id, char label) const {
-  return (node_id ^ (node_id << 5) ^ (UInt8)label) & cache_mask_;
+  return (node_id ^ (node_id << 5) ^ static_cast<UInt8>(label)) & cache_mask_;
 }
 
 std::size_t LoudsTrie::get_cache_id(std::size_t node_id) const {

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -85,8 +85,9 @@ void LoudsTrie::reverse_lookup(Agent &agent) const {
     if (link_flags_[state.node_id()]) {
       const std::size_t prev_key_pos = state.key_buf().size();
       restore(agent, get_link(state.node_id()));
-      std::reverse(state.key_buf().begin() + prev_key_pos,
-                   state.key_buf().end());
+      std::reverse(
+          state.key_buf().begin() + static_cast<ptrdiff_t>(prev_key_pos),
+          state.key_buf().end());
     } else {
       state.key_buf().push_back(static_cast<char>(bases_[state.node_id()]));
     }

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -360,7 +360,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
     }
 
     w_ranges.clear();
-    double weight = static_cast<double>(keys[range.begin()].weight());
+    double weight = double{keys[range.begin()].weight()};
     for (std::size_t i = range.begin() + 1; i < range.end(); ++i) {
       if (keys[i - 1][range.key_pos()] != keys[i][range.key_pos()]) {
         w_ranges.push_back(make_weighted_range(
@@ -368,7 +368,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
         range.set_begin(i);
         weight = 0.0;
       }
-      weight += static_cast<double>(keys[i].weight());
+      weight += double{keys[i].weight()};
     }
     w_ranges.push_back(make_weighted_range(range.begin(), range.end(),
                                            range.key_pos(),

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -360,7 +360,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
     }
 
     w_ranges.clear();
-    double weight = keys[range.begin()].weight();
+    double weight = static_cast<double>(keys[range.begin()].weight());
     for (std::size_t i = range.begin() + 1; i < range.end(); ++i) {
       if (keys[i - 1][range.key_pos()] != keys[i][range.key_pos()]) {
         w_ranges.push_back(make_weighted_range(
@@ -368,7 +368,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
         range.set_begin(i);
         weight = 0.0;
       }
-      weight += keys[i].weight();
+      weight += static_cast<double>(keys[i].weight());
     }
     w_ranges.push_back(make_weighted_range(range.begin(), range.end(),
                                            range.key_pos(),

--- a/lib/marisa/grimoire/trie/state.h
+++ b/lib/marisa/grimoire/trie/state.h
@@ -27,15 +27,15 @@ class State {
 
   void set_node_id(std::size_t node_id) {
     MARISA_DEBUG_IF(node_id > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    node_id_ = (UInt32)node_id;
+    node_id_ = static_cast<UInt32>(node_id);
   }
   void set_query_pos(std::size_t query_pos) {
     MARISA_DEBUG_IF(query_pos > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    query_pos_ = (UInt32)query_pos;
+    query_pos_ = static_cast<UInt32>(query_pos);
   }
   void set_history_pos(std::size_t history_pos) {
     MARISA_DEBUG_IF(history_pos > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    history_pos_ = (UInt32)history_pos;
+    history_pos_ = static_cast<UInt32>(history_pos);
   }
   void set_status_code(StatusCode status_code) {
     status_code_ = status_code;

--- a/lib/marisa/grimoire/trie/tail.cc
+++ b/lib/marisa/grimoire/trie/tail.cc
@@ -173,10 +173,10 @@ void Tail::build_(Vector<Entry> &entries, Vector<UInt32> *offsets,
       ++match;
     }
     if ((match == current.length()) && (last->length() != 0)) {
-      temp_offsets[current.id()] =
-          (UInt32)(temp_offsets[last->id()] + (last->length() - match));
+      temp_offsets[current.id()] = static_cast<UInt32>(
+          temp_offsets[last->id()] + (last->length() - match));
     } else {
-      temp_offsets[current.id()] = (UInt32)buf_.size();
+      temp_offsets[current.id()] = static_cast<UInt32>(buf_.size());
       for (std::size_t j = 1; j <= current.length(); ++j) {
         buf_.push_back(current[current.length() - j]);
       }

--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -885,22 +885,28 @@ void BitVector::build_index(const BitVector &bv, bool enables_select0,
     switch (((num_bits - 1) / 64) % 8) {
       case 0: {
         ranks_[rank_id].set_rel1(num_1s - ranks_[rank_id].abs());
-      }  // fall through
+      }
+      [[fallthrough]];
       case 1: {
         ranks_[rank_id].set_rel2(num_1s - ranks_[rank_id].abs());
-      }  // fall through
+      }
+      [[fallthrough]];
       case 2: {
         ranks_[rank_id].set_rel3(num_1s - ranks_[rank_id].abs());
-      }  // fall through
+      }
+      [[fallthrough]];
       case 3: {
         ranks_[rank_id].set_rel4(num_1s - ranks_[rank_id].abs());
-      }  // fall through
+      }
+      [[fallthrough]];
       case 4: {
         ranks_[rank_id].set_rel5(num_1s - ranks_[rank_id].abs());
-      }  // fall through
+      }
+      [[fallthrough]];
       case 5: {
         ranks_[rank_id].set_rel6(num_1s - ranks_[rank_id].abs());
-      }  // fall through
+      }
+      [[fallthrough]];
       case 6: {
         ranks_[rank_id].set_rel7(num_1s - ranks_[rank_id].abs());
         break;

--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -886,27 +886,27 @@ void BitVector::build_index(const BitVector &bv, bool enables_select0,
       case 0: {
         ranks_[rank_id].set_rel1(num_1s - ranks_[rank_id].abs());
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case 1: {
         ranks_[rank_id].set_rel2(num_1s - ranks_[rank_id].abs());
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case 2: {
         ranks_[rank_id].set_rel3(num_1s - ranks_[rank_id].abs());
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case 3: {
         ranks_[rank_id].set_rel4(num_1s - ranks_[rank_id].abs());
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case 4: {
         ranks_[rank_id].set_rel5(num_1s - ranks_[rank_id].abs());
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case 5: {
         ranks_[rank_id].set_rel6(num_1s - ranks_[rank_id].abs());
       }
-      [[fallthrough]];
+        [[fallthrough]];
       case 6: {
         ranks_[rank_id].set_rel7(num_1s - ranks_[rank_id].abs());
         break;

--- a/lib/marisa/grimoire/vector/bit-vector.h
+++ b/lib/marisa/grimoire/vector/bit-vector.h
@@ -54,8 +54,7 @@ class BitVector {
       units_.resize(units_.size() + (64 / MARISA_WORD_SIZE), 0);
     }
     if (bit) {
-      units_[size_ / MARISA_WORD_SIZE] |= static_cast<Unit>(1)
-                                          << (size_ % MARISA_WORD_SIZE);
+      units_[size_ / MARISA_WORD_SIZE] |= Unit{1} << (size_ % MARISA_WORD_SIZE);
       ++num_1s_;
     }
     ++size_;
@@ -64,7 +63,7 @@ class BitVector {
   bool operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= size_, MARISA_BOUND_ERROR);
     return (units_[i / MARISA_WORD_SIZE] &
-            (static_cast<Unit>(1) << (i % MARISA_WORD_SIZE))) != 0;
+            (Unit{1} << (i % MARISA_WORD_SIZE))) != 0;
   }
 
   std::size_t rank0(std::size_t i) const {

--- a/lib/marisa/grimoire/vector/bit-vector.h
+++ b/lib/marisa/grimoire/vector/bit-vector.h
@@ -54,7 +54,8 @@ class BitVector {
       units_.resize(units_.size() + (64 / MARISA_WORD_SIZE), 0);
     }
     if (bit) {
-      units_[size_ / MARISA_WORD_SIZE] |= (Unit)1 << (size_ % MARISA_WORD_SIZE);
+      units_[size_ / MARISA_WORD_SIZE] |= static_cast<Unit>(1)
+                                          << (size_ % MARISA_WORD_SIZE);
       ++num_1s_;
     }
     ++size_;
@@ -63,7 +64,7 @@ class BitVector {
   bool operator[](std::size_t i) const {
     MARISA_DEBUG_IF(i >= size_, MARISA_BOUND_ERROR);
     return (units_[i / MARISA_WORD_SIZE] &
-            ((Unit)1 << (i % MARISA_WORD_SIZE))) != 0;
+            (static_cast<Unit>(1) << (i % MARISA_WORD_SIZE))) != 0;
   }
 
   std::size_t rank0(std::size_t i) const {
@@ -159,8 +160,8 @@ class BitVector {
 
   void write_(Writer &writer) const {
     units_.write(writer);
-    writer.write((UInt32)size_);
-    writer.write((UInt32)num_1s_);
+    writer.write(static_cast<UInt32>(size_));
+    writer.write(static_cast<UInt32>(num_1s_));
     ranks_.write(writer);
     select0s_.write(writer);
     select1s_.write(writer);

--- a/lib/marisa/grimoire/vector/flat-vector.h
+++ b/lib/marisa/grimoire/vector/flat-vector.h
@@ -46,11 +46,11 @@ class FlatVector {
     const std::size_t unit_offset = pos % MARISA_WORD_SIZE;
 
     if ((unit_offset + value_size_) <= MARISA_WORD_SIZE) {
-      return (UInt32)(units_[unit_id] >> unit_offset) & mask_;
+      return static_cast<UInt32>(units_[unit_id] >> unit_offset) & mask_;
     } else {
-      return (UInt32)((units_[unit_id] >> unit_offset) |
-                      (units_[unit_id + 1]
-                       << (MARISA_WORD_SIZE - unit_offset))) &
+      return static_cast<UInt32>(
+                 (units_[unit_id] >> unit_offset) |
+                 (units_[unit_id + 1] << (MARISA_WORD_SIZE - unit_offset))) &
              mask_;
     }
   }
@@ -107,9 +107,10 @@ class FlatVector {
 
     std::size_t num_units = values.empty() ? 0 : (64 / MARISA_WORD_SIZE);
     if (value_size != 0) {
-      num_units = (std::size_t)((((UInt64)value_size * values.size()) +
-                                 (MARISA_WORD_SIZE - 1)) /
-                                MARISA_WORD_SIZE);
+      num_units = static_cast<std::size_t>(
+          ((static_cast<UInt64>(value_size) * values.size()) +
+           (MARISA_WORD_SIZE - 1)) /
+          MARISA_WORD_SIZE);
       num_units += num_units % (64 / MARISA_WORD_SIZE);
     }
 
@@ -146,7 +147,7 @@ class FlatVector {
       UInt64 temp_size;
       mapper.map(&temp_size);
       MARISA_THROW_IF(temp_size > MARISA_SIZE_MAX, MARISA_SIZE_ERROR);
-      size_ = (std::size_t)temp_size;
+      size_ = static_cast<std::size_t>(temp_size);
     }
   }
 
@@ -167,15 +168,15 @@ class FlatVector {
       UInt64 temp_size;
       reader.read(&temp_size);
       MARISA_THROW_IF(temp_size > MARISA_SIZE_MAX, MARISA_SIZE_ERROR);
-      size_ = (std::size_t)temp_size;
+      size_ = static_cast<std::size_t>(temp_size);
     }
   }
 
   void write_(Writer &writer) const {
     units_.write(writer);
-    writer.write((UInt32)value_size_);
-    writer.write((UInt32)mask_);
-    writer.write((UInt64)size_);
+    writer.write(static_cast<UInt32>(value_size_));
+    writer.write(static_cast<UInt32>(mask_));
+    writer.write(static_cast<UInt64>(size_));
   }
 
   void set(std::size_t i, UInt32 value) {
@@ -186,12 +187,13 @@ class FlatVector {
     const std::size_t unit_id = pos / MARISA_WORD_SIZE;
     const std::size_t unit_offset = pos % MARISA_WORD_SIZE;
 
-    units_[unit_id] &= ~((Unit)mask_ << unit_offset);
-    units_[unit_id] |= (Unit)(value & mask_) << unit_offset;
+    units_[unit_id] &= ~(static_cast<Unit>(mask_) << unit_offset);
+    units_[unit_id] |= static_cast<Unit>(value & mask_) << unit_offset;
     if ((unit_offset + value_size_) > MARISA_WORD_SIZE) {
-      units_[unit_id + 1] &= ~((Unit)mask_ >> (MARISA_WORD_SIZE - unit_offset));
+      units_[unit_id + 1] &=
+          ~(static_cast<Unit>(mask_) >> (MARISA_WORD_SIZE - unit_offset));
       units_[unit_id + 1] |=
-          (Unit)(value & mask_) >> (MARISA_WORD_SIZE - unit_offset);
+          static_cast<Unit>(value & mask_) >> (MARISA_WORD_SIZE - unit_offset);
     }
   }
 };

--- a/lib/marisa/grimoire/vector/pop-count.h
+++ b/lib/marisa/grimoire/vector/pop-count.h
@@ -11,7 +11,9 @@ namespace marisa::grimoire::vector {
 
 #if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 
-using std::popcount;
+inline std::size_t popcount(UInt64 x) {
+  return static_cast<std::size_t>(std::popcount(x));
+}
 
 #else  // c++17
 

--- a/lib/marisa/grimoire/vector/rank-index.h
+++ b/lib/marisa/grimoire/vector/rank-index.h
@@ -11,35 +11,40 @@ class RankIndex {
 
   void set_abs(std::size_t value) {
     MARISA_DEBUG_IF(value > MARISA_UINT32_MAX, MARISA_SIZE_ERROR);
-    abs_ = (UInt32)value;
+    abs_ = static_cast<UInt32>(value);
   }
   void set_rel1(std::size_t value) {
     MARISA_DEBUG_IF(value > 64, MARISA_RANGE_ERROR);
-    rel_lo_ = (UInt32)((rel_lo_ & ~0x7FU) | (value & 0x7FU));
+    rel_lo_ = static_cast<UInt32>((rel_lo_ & ~0x7FU) | (value & 0x7FU));
   }
   void set_rel2(std::size_t value) {
     MARISA_DEBUG_IF(value > 128, MARISA_RANGE_ERROR);
-    rel_lo_ = (UInt32)((rel_lo_ & ~(0xFFU << 7)) | ((value & 0xFFU) << 7));
+    rel_lo_ =
+        static_cast<UInt32>((rel_lo_ & ~(0xFFU << 7)) | ((value & 0xFFU) << 7));
   }
   void set_rel3(std::size_t value) {
     MARISA_DEBUG_IF(value > 192, MARISA_RANGE_ERROR);
-    rel_lo_ = (UInt32)((rel_lo_ & ~(0xFFU << 15)) | ((value & 0xFFU) << 15));
+    rel_lo_ = static_cast<UInt32>((rel_lo_ & ~(0xFFU << 15)) |
+                                  ((value & 0xFFU) << 15));
   }
   void set_rel4(std::size_t value) {
     MARISA_DEBUG_IF(value > 256, MARISA_RANGE_ERROR);
-    rel_lo_ = (UInt32)((rel_lo_ & ~(0x1FFU << 23)) | ((value & 0x1FFU) << 23));
+    rel_lo_ = static_cast<UInt32>((rel_lo_ & ~(0x1FFU << 23)) |
+                                  ((value & 0x1FFU) << 23));
   }
   void set_rel5(std::size_t value) {
     MARISA_DEBUG_IF(value > 320, MARISA_RANGE_ERROR);
-    rel_hi_ = (UInt32)((rel_hi_ & ~0x1FFU) | (value & 0x1FFU));
+    rel_hi_ = static_cast<UInt32>((rel_hi_ & ~0x1FFU) | (value & 0x1FFU));
   }
   void set_rel6(std::size_t value) {
     MARISA_DEBUG_IF(value > 384, MARISA_RANGE_ERROR);
-    rel_hi_ = (UInt32)((rel_hi_ & ~(0x1FFU << 9)) | ((value & 0x1FFU) << 9));
+    rel_hi_ = static_cast<UInt32>((rel_hi_ & ~(0x1FFU << 9)) |
+                                  ((value & 0x1FFU) << 9));
   }
   void set_rel7(std::size_t value) {
     MARISA_DEBUG_IF(value > 448, MARISA_RANGE_ERROR);
-    rel_hi_ = (UInt32)((rel_hi_ & ~(0x1FFU << 18)) | ((value & 0x1FFU) << 18));
+    rel_hi_ = static_cast<UInt32>((rel_hi_ & ~(0x1FFU << 18)) |
+                                  ((value & 0x1FFU) << 18));
   }
 
   std::size_t abs() const {

--- a/lib/marisa/grimoire/vector/vector.h
+++ b/lib/marisa/grimoire/vector/vector.h
@@ -194,7 +194,7 @@ class Vector {
     return sizeof(T) * size_;
   }
   std::size_t io_size() const {
-    return sizeof(UInt64) + ((total_size() + 7) & ~(std::size_t)0x07);
+    return sizeof(UInt64) + ((total_size() + 7) & ~0x07U);
   }
 
   void clear() {
@@ -226,9 +226,9 @@ class Vector {
     mapper.map(&total_size);
     MARISA_THROW_IF(total_size > MARISA_SIZE_MAX, MARISA_SIZE_ERROR);
     MARISA_THROW_IF((total_size % sizeof(T)) != 0, MARISA_FORMAT_ERROR);
-    const std::size_t size = (std::size_t)(total_size / sizeof(T));
+    const std::size_t size = static_cast<std::size_t>(total_size / sizeof(T));
     mapper.map(&const_objs_, size);
-    mapper.seek((std::size_t)((8 - (total_size % 8)) % 8));
+    mapper.seek(static_cast<std::size_t>((8 - (total_size % 8)) % 8));
     size_ = size;
     fix();
   }
@@ -237,13 +237,13 @@ class Vector {
     reader.read(&total_size);
     MARISA_THROW_IF(total_size > MARISA_SIZE_MAX, MARISA_SIZE_ERROR);
     MARISA_THROW_IF((total_size % sizeof(T)) != 0, MARISA_FORMAT_ERROR);
-    const std::size_t size = (std::size_t)(total_size / sizeof(T));
+    const std::size_t size = static_cast<std::size_t>(total_size / sizeof(T));
     resize(size);
     reader.read(objs_, size);
-    reader.seek((std::size_t)((8 - (total_size % 8)) % 8));
+    reader.seek(static_cast<std::size_t>((8 - (total_size % 8)) % 8));
   }
   void write_(Writer &writer) const {
-    writer.write((UInt64)total_size());
+    writer.write(static_cast<UInt64>(total_size()));
     writer.write(const_objs_, size_);
     writer.seek((8 - (total_size() % 8)) % 8);
   }

--- a/tests/base-test.cc
+++ b/tests/base-test.cc
@@ -102,7 +102,7 @@ void TestKey() {
 
   key.set_weight(1.0);
 
-  ASSERT(key.weight() == 1.0);
+  ASSERT(key.weight() == 1.0F);
 
   key.set_id(100);
 
@@ -137,7 +137,7 @@ void TestKeyset() {
     ASSERT(keyset[i].length() == keys[i].length());
     ASSERT(std::memcmp(keyset[i].ptr(), keys[i].c_str(), keyset[i].length()) ==
            0);
-    ASSERT(keyset[i].weight() == 1.0);
+    ASSERT(keyset[i].weight() == 1.0F);
   }
 
   keyset.clear();
@@ -156,7 +156,7 @@ void TestKeyset() {
     ASSERT(std::memcmp(keyset[i].ptr(), keys[i].c_str(), keyset[i].length()) ==
            0);
     ASSERT(keyset[i].str() == keys[i]);
-    ASSERT(keyset[i].weight() == 2.0);
+    ASSERT(keyset[i].weight() == 2.0F);
   }
 
   keyset.clear();

--- a/tests/io-test.cc
+++ b/tests/io-test.cc
@@ -22,8 +22,8 @@ void TestFilename() {
     marisa::grimoire::Writer writer;
     writer.open("io-test.dat");
 
-    writer.write(static_cast<marisa::UInt32>(123));
-    writer.write(static_cast<marisa::UInt32>(234));
+    writer.write(marisa::UInt32{123});
+    writer.write(marisa::UInt32{234});
 
     double values[] = {3.45, 4.56};
     writer.write(values, 2);

--- a/tests/io-test.cc
+++ b/tests/io-test.cc
@@ -22,8 +22,8 @@ void TestFilename() {
     marisa::grimoire::Writer writer;
     writer.open("io-test.dat");
 
-    writer.write((marisa::UInt32)123);
-    writer.write((marisa::UInt32)234);
+    writer.write(static_cast<marisa::UInt32>(123));
+    writer.write(static_cast<marisa::UInt32>(234));
 
     double values[] = {3.45, 4.56};
     writer.write(values, 2);

--- a/tests/marisa-test.cc
+++ b/tests/marisa-test.cc
@@ -299,20 +299,20 @@ void TestPredictiveSearchAgentCopy(const marisa::Trie &trie,
       agent_copies.push_back(agent);
     }
 
-    for (std::size_t i = 0; i < agent_copies.size(); ++i) {
+    for (std::size_t j = 0; j < agent_copies.size(); ++j) {
       marisa::Agent agent_copy;
 
       // Tests copy assignment.
-      agent_copy = agent_copies[i];
+      agent_copy = agent_copies[j];
 
-      ASSERT(agent_copy.key().id() == ids[i]);
+      ASSERT(agent_copy.key().id() == ids[j]);
       ASSERT(std::string(agent_copy.key().ptr(), agent_copy.key().length()) ==
-             keys[i]);
-      if (i + 1 < agent_copies.size()) {
+             keys[j]);
+      if (j + 1 < agent_copies.size()) {
         ASSERT(trie.predictive_search(agent_copy));
-        ASSERT(agent_copy.key().id() == ids[i + 1]);
+        ASSERT(agent_copy.key().id() == ids[j + 1]);
         ASSERT(std::string(agent_copy.key().ptr(), agent_copy.key().length()) ==
-               keys[i + 1]);
+               keys[j + 1]);
       } else {
         ASSERT(!trie.predictive_search(agent_copy));
       }

--- a/tests/marisa-test.cc
+++ b/tests/marisa-test.cc
@@ -357,7 +357,7 @@ void TestTrie(int num_tries, marisa::TailMode tail_mode,
   marisa::Trie trie;
   trie.build(keyset, num_tries | tail_mode | node_order);
 
-  ASSERT(trie.num_tries() == (std::size_t)num_tries);
+  ASSERT(trie.num_tries() == static_cast<std::size_t>(num_tries));
   ASSERT(trie.num_keys() <= keyset.size());
 
   ASSERT(trie.tail_mode() == tail_mode);
@@ -375,7 +375,7 @@ void TestTrie(int num_tries, marisa::TailMode tail_mode,
   trie.clear();
   trie.load("marisa-test.dat");
 
-  ASSERT(trie.num_tries() == (std::size_t)num_tries);
+  ASSERT(trie.num_tries() == static_cast<std::size_t>(num_tries));
   ASSERT(trie.num_keys() <= keyset.size());
 
   ASSERT(trie.tail_mode() == tail_mode);
@@ -404,7 +404,7 @@ void TestTrie(int num_tries, marisa::TailMode tail_mode,
     std::fclose(file);
   }
 
-  ASSERT(trie.num_tries() == (std::size_t)num_tries);
+  ASSERT(trie.num_tries() == static_cast<std::size_t>(num_tries));
   ASSERT(trie.num_keys() <= keyset.size());
 
   ASSERT(trie.tail_mode() == tail_mode);
@@ -415,7 +415,7 @@ void TestTrie(int num_tries, marisa::TailMode tail_mode,
   trie.clear();
   trie.mmap("marisa-test.dat");
 
-  ASSERT(trie.num_tries() == (std::size_t)num_tries);
+  ASSERT(trie.num_tries() == static_cast<std::size_t>(num_tries));
   ASSERT(trie.num_keys() <= keyset.size());
 
   ASSERT(trie.tail_mode() == tail_mode);
@@ -430,7 +430,7 @@ void TestTrie(int num_tries, marisa::TailMode tail_mode,
     stream >> trie;
   }
 
-  ASSERT(trie.num_tries() == (std::size_t)num_tries);
+  ASSERT(trie.num_tries() == static_cast<std::size_t>(num_tries));
   ASSERT(trie.num_keys() <= keyset.size());
 
   ASSERT(trie.tail_mode() == tail_mode);

--- a/tools/marisa-benchmark.cc
+++ b/tools/marisa-benchmark.cc
@@ -143,7 +143,8 @@ void read_keys(std::istream &input, marisa::Keyset *keyset,
     float weight = 1.0F;
     if (delim_pos != line.npos) {
       char *end_of_value;
-      weight = (float)std::strtod(&line[delim_pos + 1], &end_of_value);
+      weight =
+          static_cast<float>(std::strtod(&line[delim_pos + 1], &end_of_value));
       if (*end_of_value == '\0') {
         line.resize(delim_pos);
       }
@@ -179,7 +180,7 @@ void benchmark_build(marisa::Keyset &keyset, const std::vector<float> &weights,
   Clock cl;
   trie->build(keyset, num_tries | param_tail_mode | param_node_order |
                           param_cache_level);
-  std::printf(" %10lu", (unsigned long)trie->io_size());
+  std::printf(" %10lu", static_cast<unsigned long>(trie->io_size()));
   print_time_info(keyset.size(), cl.elasped());
 }
 
@@ -402,7 +403,7 @@ int main(int argc, char *argv[]) {
                     << cmdopt.optarg << std::endl;
           return 1;
         }
-        param_min_num_tries = (int)value;
+        param_min_num_tries = static_cast<int>(value);
         break;
       }
       case 'n': {
@@ -414,7 +415,7 @@ int main(int argc, char *argv[]) {
                     << cmdopt.optarg << std::endl;
           return 2;
         }
-        param_max_num_tries = (int)value;
+        param_max_num_tries = static_cast<int>(value);
         break;
       }
       case 't': {

--- a/tools/marisa-build.cc
+++ b/tools/marisa-build.cc
@@ -47,7 +47,8 @@ void read_keys(std::istream &input, marisa::Keyset *keyset) {
     float weight = 1.0F;
     if (delim_pos != line.npos) {
       char *end_of_value;
-      weight = (float)std::strtod(&line[delim_pos + 1], &end_of_value);
+      weight =
+          static_cast<float>(std::strtod(&line[delim_pos + 1], &end_of_value));
       if (*end_of_value == '\0') {
         line.resize(delim_pos);
       }
@@ -155,7 +156,7 @@ int main(int argc, char *argv[]) {
                     << cmdopt.optarg << std::endl;
           return 1;
         }
-        param_num_tries = (int)value;
+        param_num_tries = static_cast<int>(value);
         break;
       }
       case 't': {

--- a/tools/marisa-common-prefix-search.cc
+++ b/tools/marisa-common-prefix-search.cc
@@ -117,10 +117,11 @@ int main(int argc, char *argv[]) {
           std::cerr << "error: option `-n' with an invalid argument: "
                     << cmdopt.optarg << std::endl;
         }
-        if ((value == 0) || ((unsigned long long)value > MARISA_SIZE_MAX)) {
+        if ((value == 0) ||
+            (static_cast<unsigned long long>(value) > MARISA_SIZE_MAX)) {
           max_num_results = MARISA_SIZE_MAX;
         } else {
-          max_num_results = (std::size_t)value;
+          max_num_results = static_cast<std::size_t>(value);
         }
         break;
       }

--- a/tools/marisa-predictive-search.cc
+++ b/tools/marisa-predictive-search.cc
@@ -117,10 +117,11 @@ int main(int argc, char *argv[]) {
           std::cerr << "error: option `-n' with an invalid argument: "
                     << cmdopt.optarg << std::endl;
         }
-        if ((value == 0) || ((unsigned long long)value > MARISA_SIZE_MAX)) {
+        if ((value == 0) ||
+            (static_cast<unsigned long long>(value) > MARISA_SIZE_MAX)) {
           max_num_results = MARISA_SIZE_MAX;
         } else {
-          max_num_results = (std::size_t)value;
+          max_num_results = static_cast<std::size_t>(value);
         }
         break;
       }


### PR DESCRIPTION
* [x] -Wall
* [x] -Wextra # reasonable and standard
* [x] -Wshadow # warn the user if a variable declaration shadows one from a parent context
* [x] -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
* [x] -Wold-style-cast # warn for c-style casts
* [x] -Wcast-align # warn for potential performance problem casts
* [x] -Wunused # warn on anything being unused
* [x] -Woverloaded-virtual # warn if you overload (not override) a virtual function
* [x] -Wpedantic # warn if non-standard C++ is used
* [x] -Wconversion # warn on type conversions that may lose data
* [x] -Wsign-conversion # warn on sign conversions
* [x] -Wnull-dereference # warn if a null dereference is detected
* [x] -Wdouble-promotion # warn if float is implicit promoted to double
* [x] -Wformat=2 # warn on security issues around functions that format output (ie printf)
* [x] -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
