### PR TITLE
windows.yml: Depend on actions/checkout hash

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
The other github/workflows/*.yml files use hashes to prevent compromise of dependencies.  Do the same here.