### PR TITLE
Throw std::system_error instead of std::runtime_error

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -185,10 +185,11 @@ using Exception = std::exception;
 
 // MARISA_THROW_SYSTEM_ERROR_IF throws an exception if `condition` is true.
 // ::GetLastError() or errno should be passed as `error_value`.
-#define MARISA_THROW_SYSTEM_ERROR_IF(condition, error_value, function_name)    \
+#define MARISA_THROW_SYSTEM_ERROR_IF(condition, error_value, error_category,   \
+                                     function_name)                            \
   (void)((!(condition)) ||                                                     \
          (throw std::system_error(                                             \
-              std::error_code(error_value, std::system_category()),            \
+              std::error_code(error_value, error_category),                    \
               __FILE__ ":" MARISA_LINE_STR                                     \
                        ": std::system_error: " function_name ": " #condition), \
           false))

--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <system_error>
 #include <utility>
 
 // These aliases are left for backward compatibility.
@@ -181,6 +182,16 @@ using Exception = std::exception;
 // MARISA_THROW_IF throws an exception if `condition' is true.
 #define MARISA_THROW_IF(condition, error_type) \
   (void)((!(condition)) || (MARISA_THROW(error_type, #condition), 0))
+
+// MARISA_THROW_SYSTEM_ERROR_IF throws an exception if `condition` is true.
+// ::GetLastError() or errno should be passed as `error_value`.
+#define MARISA_THROW_SYSTEM_ERROR_IF(condition, error_value, function_name)    \
+  (void)((!(condition)) ||                                                     \
+         (throw std::system_error(                                             \
+              std::error_code(error_value, std::system_category()),            \
+              __FILE__ ":" MARISA_LINE_STR                                     \
+                       ": std::system_error: " function_name ": " #condition), \
+          false))
 
 // #ifndef MARISA_USE_EXCEPTIONS
 //  #if defined(__GNUC__) && !defined(__EXCEPTIONS)

--- a/lib/marisa/grimoire/io/reader.cc
+++ b/lib/marisa/grimoire/io/reader.cc
@@ -87,10 +87,12 @@ void Reader::open_(const char *filename) {
   std::FILE *file = nullptr;
 #ifdef _MSC_VER
   const errno_t error_value = ::fopen_s(&file, filename, "rb");
-  MARISA_THROW_SYSTEM_ERROR_IF(error_value != 0, error_value, "fopen_s");
+  MARISA_THROW_SYSTEM_ERROR_IF(error_value != 0, error_value,
+                               std::generic_category(), "fopen_s");
 #else   // _MSC_VER
   file = std::fopen(filename, "rb");
-  MARISA_THROW_SYSTEM_ERROR_IF(file == nullptr, errno, "std::fopen");
+  MARISA_THROW_SYSTEM_ERROR_IF(file == nullptr, errno, std::generic_category(),
+                               "std::fopen");
 #endif  // _MSC_VER
   file_ = file;
   needs_fclose_ = true;
@@ -119,19 +121,21 @@ void Reader::read_data(void *buf, std::size_t size) {
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits<int>::max();
       const unsigned int count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
       const int size_read = ::_read(fd_, buf, count);
-      MARISA_THROW_SYSTEM_ERROR_IF(size_read <= 0, errno, "_read");
+      MARISA_THROW_SYSTEM_ERROR_IF(size_read <= 0, errno,
+                                   std::generic_category(), "_read");
 #else   // _WIN32
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits< ::ssize_t>::max();
       const ::size_t count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
       const ::ssize_t size_read = ::read(fd_, buf, count);
-      MARISA_THROW_SYSTEM_ERROR_IF(size_read <= 0, errno, "read");
+      MARISA_THROW_SYSTEM_ERROR_IF(size_read <= 0, errno,
+                                   std::generic_category(), "read");
 #endif  // _WIN32
       buf = static_cast<char *>(buf) + size_read;
       size -= static_cast<std::size_t>(size_read);
     }
   } else if (file_ != nullptr) {
     MARISA_THROW_SYSTEM_ERROR_IF(std::fread(buf, 1, size, file_) != size, errno,
-                                 "std::fread");
+                                 std::generic_category(), "std::fread");
   } else if (stream_ != nullptr) {
     MARISA_THROW_IF(!stream_->read(static_cast<char *>(buf),
                                    static_cast<std::streamsize>(size)),

--- a/lib/marisa/grimoire/io/writer.cc
+++ b/lib/marisa/grimoire/io/writer.cc
@@ -87,10 +87,12 @@ void Writer::open_(const char *filename) {
   std::FILE *file = nullptr;
 #ifdef _MSC_VER
   const errno_t error_value = ::fopen_s(&file, filename, "wb");
-  MARISA_THROW_SYSTEM_ERROR_IF(error_value != 0, error_value, "fopen_s");
+  MARISA_THROW_SYSTEM_ERROR_IF(error_value != 0, error_value,
+                               std::generic_category(), "fopen_s");
 #else   // _MSC_VER
   file = std::fopen(filename, "wb");
-  MARISA_THROW_SYSTEM_ERROR_IF(file == nullptr, errno, "std::fopen");
+  MARISA_THROW_SYSTEM_ERROR_IF(file == nullptr, errno, std::generic_category(),
+                               "std::fopen");
 #endif  // _MSC_VER
   file_ = file;
   needs_fclose_ = true;
@@ -119,20 +121,23 @@ void Writer::write_data(const void *data, std::size_t size) {
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits<int>::max();
       const unsigned int count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
       const int size_written = ::_write(fd_, data, count);
-      MARISA_THROW_SYSTEM_ERROR_IF(size_written <= 0, errno, "_write");
+      MARISA_THROW_SYSTEM_ERROR_IF(size_written <= 0, errno,
+                                   std::generic_category(), "_write");
 #else   // _WIN32
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits< ::ssize_t>::max();
       const ::size_t count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
       const ::ssize_t size_written = ::write(fd_, data, count);
-      MARISA_THROW_SYSTEM_ERROR_IF(size_written <= 0, errno, "write");
+      MARISA_THROW_SYSTEM_ERROR_IF(size_written <= 0, errno,
+                                   std::generic_category(), "write");
 #endif  // _WIN32
       data = static_cast<const char *>(data) + size_written;
       size -= static_cast<std::size_t>(size_written);
     }
   } else if (file_ != nullptr) {
     MARISA_THROW_SYSTEM_ERROR_IF(std::fwrite(data, 1, size, file_) != size,
-                                 errno, "std::fwrite");
-    MARISA_THROW_SYSTEM_ERROR_IF(std::fflush(file_) != 0, errno, "std::fflush");
+                                 errno, std::generic_category(), "std::fwrite");
+    MARISA_THROW_SYSTEM_ERROR_IF(std::fflush(file_) != 0, errno,
+                                 std::generic_category(), "std::fflush");
   } else if (stream_ != nullptr) {
     MARISA_THROW_IF(!stream_->write(static_cast<const char *>(data),
                                     static_cast<std::streamsize>(size)),


### PR DESCRIPTION
`std::system_error` allows passing an error code (`::GetLastError()` or `errno`).
This improvement was proposed in #114.
