### PR TITLE
Use uintXX_t instead of UIntXX

### DIFF
--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -149,10 +149,16 @@ enum marisa_config_mask {
 
 namespace marisa {
 
-using UInt8 = std::uint8_t;
-using UInt16 = std::uint16_t;
-using UInt32 = std::uint32_t;
-using UInt64 = std::uint64_t;
+// These aliases are left for backward compatibility.
+using UInt8 [[deprecated]] = std::uint8_t;
+using UInt16 [[deprecated]] = std::uint16_t;
+using UInt32 [[deprecated]] = std::uint32_t;
+using UInt64 [[deprecated]] = std::uint64_t;
+
+using std::uint16_t;
+using std::uint32_t;
+using std::uint64_t;
+using std::uint8_t;
 
 using ErrorCode = marisa_error_code;
 using CacheLevel = marisa_cache_level;

--- a/include/marisa/key.h
+++ b/include/marisa/key.h
@@ -30,17 +30,17 @@ class Key {
     }
     assert(length <= UINT32_MAX);
     ptr_ = str;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
   void set_str(const char *ptr, std::size_t length) {
     assert((ptr != nullptr) || (length == 0));
     assert(length <= UINT32_MAX);
     ptr_ = ptr;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
   void set_id(std::size_t id) {
     assert(id <= UINT32_MAX);
-    union_.id = static_cast<UInt32>(id);
+    union_.id = static_cast<uint32_t>(id);
   }
   void set_weight(float weight) {
     union_.weight = weight;
@@ -73,9 +73,9 @@ class Key {
 
  private:
   const char *ptr_ = nullptr;
-  UInt32 length_ = 0;
+  uint32_t length_ = 0;
   union Union {
-    UInt32 id = 0;
+    uint32_t id = 0;
     float weight;
   } union_;
 };

--- a/lib/marisa/grimoire/algorithm/sort.h
+++ b/lib/marisa/grimoire/algorithm/sort.h
@@ -16,7 +16,7 @@ template <typename T>
 int get_label(const T &unit, std::size_t depth) {
   assert(depth <= unit.length());
 
-  return (depth < unit.length()) ? int{static_cast<UInt8>(unit[depth])} : -1;
+  return (depth < unit.length()) ? int{static_cast<uint8_t>(unit[depth])} : -1;
 }
 
 template <typename T>
@@ -46,7 +46,7 @@ int compare(const T &lhs, const T &rhs, std::size_t depth) {
       return 1;
     }
     if (lhs[i] != rhs[i]) {
-      return static_cast<UInt8>(lhs[i]) - static_cast<UInt8>(rhs[i]);
+      return static_cast<uint8_t>(lhs[i]) - static_cast<uint8_t>(rhs[i]);
     }
   }
   if (lhs.length() == rhs.length()) {

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -149,7 +149,7 @@ void Mapper::open_(const char *filename, int flags) {
   struct stat st;
   MARISA_THROW_SYSTEM_ERROR_IF(::fstat(fd_, &st) != 0, errno,
                                std::generic_category(), "fstat");
-  MARISA_THROW_IF(static_cast<UInt64>(st.st_size) > SIZE_MAX,
+  MARISA_THROW_IF(static_cast<uint64_t>(st.st_size) > SIZE_MAX,
                   std::runtime_error);
   size_ = static_cast<std::size_t>(st.st_size);
 

--- a/lib/marisa/grimoire/trie/cache.h
+++ b/lib/marisa/grimoire/trie/cache.h
@@ -16,18 +16,18 @@ class Cache {
 
   void set_parent(std::size_t parent) {
     assert(parent <= UINT32_MAX);
-    parent_ = static_cast<UInt32>(parent);
+    parent_ = static_cast<uint32_t>(parent);
   }
   void set_child(std::size_t child) {
     assert(child <= UINT32_MAX);
-    child_ = static_cast<UInt32>(child);
+    child_ = static_cast<uint32_t>(child);
   }
-  void set_base(UInt8 base) {
+  void set_base(uint8_t base) {
     union_.link = (union_.link & ~0xFFU) | base;
   }
   void set_extra(std::size_t extra) {
     assert(extra <= (UINT32_MAX >> 8));
-    union_.link = static_cast<UInt32>((union_.link & 0xFFU) | (extra << 8));
+    union_.link = static_cast<uint32_t>((union_.link & 0xFFU) | (extra << 8));
   }
   void set_weight(float weight) {
     union_.weight = weight;
@@ -39,8 +39,8 @@ class Cache {
   std::size_t child() const {
     return child_;
   }
-  UInt8 base() const {
-    return static_cast<UInt8>(union_.link & 0xFFU);
+  uint8_t base() const {
+    return static_cast<uint8_t>(union_.link & 0xFFU);
   }
   std::size_t extra() const {
     return union_.link >> 8;
@@ -56,10 +56,10 @@ class Cache {
   }
 
  private:
-  UInt32 parent_ = 0;
-  UInt32 child_ = 0;
+  uint32_t parent_ = 0;
+  uint32_t child_ = 0;
   union Union {
-    UInt32 link;
+    uint32_t link;
     float weight = FLT_MIN;
   } union_;
 };

--- a/lib/marisa/grimoire/trie/entry.h
+++ b/lib/marisa/grimoire/trie/entry.h
@@ -22,11 +22,11 @@ class Entry {
     assert((ptr != nullptr) || (length == 0));
     assert(length <= UINT32_MAX);
     ptr_ = ptr + length - 1;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
   void set_id(std::size_t id) {
     assert(id <= UINT32_MAX);
-    id_ = static_cast<UInt32>(id);
+    id_ = static_cast<uint32_t>(id);
   }
 
   const char *ptr() const {
@@ -47,7 +47,7 @@ class Entry {
           return true;
         }
         if (lhs[i] != rhs[i]) {
-          return static_cast<UInt8>(lhs[i]) > static_cast<UInt8>(rhs[i]);
+          return static_cast<uint8_t>(lhs[i]) > static_cast<uint8_t>(rhs[i]);
         }
       }
       return lhs.length() > rhs.length();
@@ -63,8 +63,8 @@ class Entry {
 
  private:
   const char *ptr_ = nullptr;
-  UInt32 length_ = 0;
-  UInt32 id_ = 0;
+  uint32_t length_ = 0;
+  uint32_t id_ = 0;
 };
 
 }  // namespace marisa::grimoire::trie

--- a/lib/marisa/grimoire/trie/history.h
+++ b/lib/marisa/grimoire/trie/history.h
@@ -13,23 +13,23 @@ class History {
 
   void set_node_id(std::size_t node_id) {
     assert(node_id <= UINT32_MAX);
-    node_id_ = static_cast<UInt32>(node_id);
+    node_id_ = static_cast<uint32_t>(node_id);
   }
   void set_louds_pos(std::size_t louds_pos) {
     assert(louds_pos <= UINT32_MAX);
-    louds_pos_ = static_cast<UInt32>(louds_pos);
+    louds_pos_ = static_cast<uint32_t>(louds_pos);
   }
   void set_key_pos(std::size_t key_pos) {
     assert(key_pos <= UINT32_MAX);
-    key_pos_ = static_cast<UInt32>(key_pos);
+    key_pos_ = static_cast<uint32_t>(key_pos);
   }
   void set_link_id(std::size_t link_id) {
     assert(link_id <= UINT32_MAX);
-    link_id_ = static_cast<UInt32>(link_id);
+    link_id_ = static_cast<uint32_t>(link_id);
   }
   void set_key_id(std::size_t key_id) {
     assert(key_id <= UINT32_MAX);
-    key_id_ = static_cast<UInt32>(key_id);
+    key_id_ = static_cast<uint32_t>(key_id);
   }
 
   std::size_t node_id() const {
@@ -49,11 +49,11 @@ class History {
   }
 
  private:
-  UInt32 node_id_ = 0;
-  UInt32 louds_pos_ = 0;
-  UInt32 key_pos_ = 0;
-  UInt32 link_id_ = MARISA_INVALID_LINK_ID;
-  UInt32 key_id_ = MARISA_INVALID_KEY_ID;
+  uint32_t node_id_ = 0;
+  uint32_t louds_pos_ = 0;
+  uint32_t key_pos_ = 0;
+  uint32_t link_id_ = MARISA_INVALID_LINK_ID;
+  uint32_t key_id_ = MARISA_INVALID_KEY_ID;
 };
 
 }  // namespace marisa::grimoire::trie

--- a/lib/marisa/grimoire/trie/key.h
+++ b/lib/marisa/grimoire/trie/key.h
@@ -23,25 +23,25 @@ class Key {
     assert(length <= length_);
     assert(pos <= (length_ - length));
     ptr_ += pos;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
 
   void set_str(const char *ptr, std::size_t length) {
     assert((ptr != nullptr) || (length == 0));
     assert(length <= UINT32_MAX);
     ptr_ = ptr;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
   void set_weight(float weight) {
     union_.weight = weight;
   }
   void set_terminal(std::size_t terminal) {
     assert(terminal <= UINT32_MAX);
-    union_.terminal = static_cast<UInt32>(terminal);
+    union_.terminal = static_cast<uint32_t>(terminal);
   }
   void set_id(std::size_t id) {
     assert(id <= UINT32_MAX);
-    id_ = static_cast<UInt32>(id);
+    id_ = static_cast<uint32_t>(id);
   }
 
   const char *ptr() const {
@@ -62,12 +62,12 @@ class Key {
 
  private:
   const char *ptr_ = nullptr;
-  UInt32 length_ = 0;
+  uint32_t length_ = 0;
   union Union {
     float weight;
-    UInt32 terminal = 0;
+    uint32_t terminal = 0;
   } union_;
-  UInt32 id_ = 0;
+  uint32_t id_ = 0;
 };
 
 inline bool operator==(const Key &lhs, const Key &rhs) {
@@ -92,7 +92,7 @@ inline bool operator<(const Key &lhs, const Key &rhs) {
       return false;
     }
     if (lhs[i] != rhs[i]) {
-      return static_cast<UInt8>(lhs[i]) < static_cast<UInt8>(rhs[i]);
+      return static_cast<uint8_t>(lhs[i]) < static_cast<uint8_t>(rhs[i]);
     }
   }
   return lhs.length() < rhs.length();
@@ -118,25 +118,25 @@ class ReverseKey {
     assert(length <= length_);
     assert(pos <= (length_ - length));
     ptr_ -= pos;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
 
   void set_str(const char *ptr, std::size_t length) {
     assert((ptr != nullptr) || (length == 0));
     assert(length <= UINT32_MAX);
     ptr_ = ptr + length;
-    length_ = static_cast<UInt32>(length);
+    length_ = static_cast<uint32_t>(length);
   }
   void set_weight(float weight) {
     union_.weight = weight;
   }
   void set_terminal(std::size_t terminal) {
     assert(terminal <= UINT32_MAX);
-    union_.terminal = static_cast<UInt32>(terminal);
+    union_.terminal = static_cast<uint32_t>(terminal);
   }
   void set_id(std::size_t id) {
     assert(id <= UINT32_MAX);
-    id_ = static_cast<UInt32>(id);
+    id_ = static_cast<uint32_t>(id);
   }
 
   const char *ptr() const {
@@ -157,12 +157,12 @@ class ReverseKey {
 
  private:
   const char *ptr_ = nullptr;
-  UInt32 length_ = 0;
+  uint32_t length_ = 0;
   union Union {
     float weight;
-    UInt32 terminal = 0;
+    uint32_t terminal = 0;
   } union_;
-  UInt32 id_ = 0;
+  uint32_t id_ = 0;
 };
 
 inline bool operator==(const ReverseKey &lhs, const ReverseKey &rhs) {
@@ -187,7 +187,7 @@ inline bool operator<(const ReverseKey &lhs, const ReverseKey &rhs) {
       return false;
     }
     if (lhs[i] != rhs[i]) {
-      return static_cast<UInt8>(lhs[i]) < static_cast<UInt8>(rhs[i]);
+      return static_cast<uint8_t>(lhs[i]) < static_cast<uint8_t>(rhs[i]);
     }
   }
   return lhs.length() < rhs.length();

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -222,7 +222,7 @@ std::size_t LoudsTrie::io_size() const {
          tail_.io_size() +
          ((next_trie_ != nullptr) ? (next_trie_->io_size() - Header().io_size())
                                   : 0) +
-         cache_.io_size() + (sizeof(UInt32) * 2);
+         cache_.io_size() + (sizeof(uint32_t) * 2);
 }
 
 void LoudsTrie::clear() noexcept {
@@ -252,15 +252,15 @@ void LoudsTrie::build_(Keyset &keyset, const Config &config) {
     keys[i].set_weight(keyset[i].weight());
   }
 
-  Vector<UInt32> terminals;
+  Vector<uint32_t> terminals;
   build_trie(keys, &terminals, config, 1);
 
-  using TerminalIdPair = std::pair<UInt32, UInt32>;
+  using TerminalIdPair = std::pair<uint32_t, uint32_t>;
   const std::size_t pairs_size = terminals.size();
   std::unique_ptr<TerminalIdPair[]> pairs(new TerminalIdPair[pairs_size]);
   for (std::size_t i = 0; i < pairs_size; ++i) {
     pairs[i].first = terminals[i];
-    pairs[i].second = static_cast<UInt32>(i);
+    pairs[i].second = static_cast<uint32_t>(i);
   }
   terminals.clear();
   std::sort(pairs.get(), pairs.get() + pairs_size);
@@ -289,11 +289,11 @@ void LoudsTrie::build_(Keyset &keyset, const Config &config) {
 }
 
 template <typename T>
-void LoudsTrie::build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+void LoudsTrie::build_trie(Vector<T> &keys, Vector<uint32_t> *terminals,
                            const Config &config, std::size_t trie_id) {
   build_current_trie(keys, terminals, config, trie_id);
 
-  Vector<UInt32> next_terminals;
+  Vector<uint32_t> next_terminals;
   if (!keys.empty()) {
     build_next_trie(keys, &next_terminals, config, trie_id);
   }
@@ -312,7 +312,7 @@ void LoudsTrie::build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
     while (!link_flags_[node_id]) {
       ++node_id;
     }
-    bases_[node_id] = static_cast<UInt8>(next_terminals[i] % 256);
+    bases_[node_id] = static_cast<uint8_t>(next_terminals[i] % 256);
     next_terminals[i] /= 256;
     ++node_id;
   }
@@ -321,7 +321,7 @@ void LoudsTrie::build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
 }
 
 template <typename T>
-void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<uint32_t> *terminals,
                                    const Config &config, std::size_t trie_id) {
   for (std::size_t i = 0; i < keys.size(); ++i) {
     keys[i].set_id(i);
@@ -427,7 +427,7 @@ void LoudsTrie::build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
 }
 
 template <>
-void LoudsTrie::build_next_trie(Vector<Key> &keys, Vector<UInt32> *terminals,
+void LoudsTrie::build_next_trie(Vector<Key> &keys, Vector<uint32_t> *terminals,
                                 const Config &config, std::size_t trie_id) {
   if (trie_id == config.num_tries()) {
     Vector<Entry> entries;
@@ -451,8 +451,8 @@ void LoudsTrie::build_next_trie(Vector<Key> &keys, Vector<UInt32> *terminals,
 
 template <>
 void LoudsTrie::build_next_trie(Vector<ReverseKey> &keys,
-                                Vector<UInt32> *terminals, const Config &config,
-                                std::size_t trie_id) {
+                                Vector<uint32_t> *terminals,
+                                const Config &config, std::size_t trie_id) {
   if (trie_id == config.num_tries()) {
     Vector<Entry> entries;
     entries.resize(keys.size());
@@ -468,11 +468,11 @@ void LoudsTrie::build_next_trie(Vector<ReverseKey> &keys,
 
 template <typename T>
 void LoudsTrie::build_terminals(const Vector<T> &keys,
-                                Vector<UInt32> *terminals) const {
-  Vector<UInt32> temp;
+                                Vector<uint32_t> *terminals) const {
+  Vector<uint32_t> temp;
   temp.resize(keys.size());
   for (std::size_t i = 0; i < keys.size(); ++i) {
-    temp[keys[i].id()] = static_cast<UInt32>(keys[i].terminal());
+    temp[keys[i].id()] = static_cast<uint32_t>(keys[i].terminal());
   }
   terminals->swap(temp);
 }
@@ -542,12 +542,12 @@ void LoudsTrie::map_(Mapper &mapper) {
   cache_.map(mapper);
   cache_mask_ = cache_.size() - 1;
   {
-    UInt32 temp_num_l1_nodes;
+    uint32_t temp_num_l1_nodes;
     mapper.map(&temp_num_l1_nodes);
     num_l1_nodes_ = temp_num_l1_nodes;
   }
   {
-    UInt32 temp_config_flags;
+    uint32_t temp_config_flags;
     mapper.map(&temp_config_flags);
     config_.parse(static_cast<int>(temp_config_flags));
   }
@@ -567,12 +567,12 @@ void LoudsTrie::read_(Reader &reader) {
   cache_.read(reader);
   cache_mask_ = cache_.size() - 1;
   {
-    UInt32 temp_num_l1_nodes;
+    uint32_t temp_num_l1_nodes;
     reader.read(&temp_num_l1_nodes);
     num_l1_nodes_ = temp_num_l1_nodes;
   }
   {
-    UInt32 temp_config_flags;
+    uint32_t temp_config_flags;
     reader.read(&temp_config_flags);
     config_.parse(static_cast<int>(temp_config_flags));
   }
@@ -589,8 +589,8 @@ void LoudsTrie::write_(Writer &writer) const {
     next_trie_->write_(writer);
   }
   cache_.write(writer);
-  writer.write(static_cast<UInt32>(num_l1_nodes_));
-  writer.write(static_cast<UInt32>(config_.flags()));
+  writer.write(static_cast<uint32_t>(num_l1_nodes_));
+  writer.write(static_cast<uint32_t>(config_.flags()));
 }
 
 bool LoudsTrie::find_child(Agent &agent) const {
@@ -628,7 +628,7 @@ bool LoudsTrie::find_child(Agent &agent) const {
         return false;
       }
     } else if (bases_[state.node_id()] ==
-               static_cast<UInt8>(agent.query()[state.query_pos()])) {
+               static_cast<uint8_t>(agent.query()[state.query_pos()])) {
       state.set_query_pos(state.query_pos() + 1);
       return true;
     }
@@ -674,7 +674,7 @@ bool LoudsTrie::predictive_find_child(Agent &agent) const {
         return false;
       }
     } else if (bases_[state.node_id()] ==
-               static_cast<UInt8>(agent.query()[state.query_pos()])) {
+               static_cast<uint8_t>(agent.query()[state.query_pos()])) {
       state.key_buf().push_back(static_cast<char>(bases_[state.node_id()]));
       state.set_query_pos(state.query_pos() + 1);
       return true;
@@ -777,7 +777,7 @@ bool LoudsTrie::match_(Agent &agent, std::size_t node_id) const {
         return false;
       }
     } else if (bases_[node_id] ==
-               static_cast<UInt8>(agent.query()[state.query_pos()])) {
+               static_cast<uint8_t>(agent.query()[state.query_pos()])) {
       state.set_query_pos(state.query_pos() + 1);
     } else {
       return false;
@@ -822,7 +822,7 @@ bool LoudsTrie::prefix_match_(Agent &agent, std::size_t node_id) const {
           return false;
         }
       } else if (bases_[node_id] ==
-                 static_cast<UInt8>(agent.query()[state.query_pos()])) {
+                 static_cast<uint8_t>(agent.query()[state.query_pos()])) {
         state.key_buf().push_back(static_cast<char>(bases_[node_id]));
         state.set_query_pos(state.query_pos() + 1);
       } else {
@@ -843,7 +843,7 @@ bool LoudsTrie::prefix_match_(Agent &agent, std::size_t node_id) const {
 }
 
 std::size_t LoudsTrie::get_cache_id(std::size_t node_id, char label) const {
-  return (node_id ^ (node_id << 5) ^ static_cast<UInt8>(label)) & cache_mask_;
+  return (node_id ^ (node_id << 5) ^ static_cast<uint8_t>(label)) & cache_mask_;
 }
 
 std::size_t LoudsTrie::get_cache_id(std::size_t node_id) const {

--- a/lib/marisa/grimoire/trie/louds-trie.h
+++ b/lib/marisa/grimoire/trie/louds-trie.h
@@ -68,7 +68,7 @@ class LoudsTrie {
   BitVector louds_;
   BitVector terminal_flags_;
   BitVector link_flags_;
-  Vector<UInt8> bases_;
+  Vector<uint8_t> bases_;
   FlatVector extras_;
   Tail tail_;
   std::unique_ptr<LoudsTrie> next_trie_;
@@ -81,16 +81,17 @@ class LoudsTrie {
   void build_(Keyset &keyset, const Config &config);
 
   template <typename T>
-  void build_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+  void build_trie(Vector<T> &keys, Vector<uint32_t> *terminals,
                   const Config &config, std::size_t trie_id);
   template <typename T>
-  void build_current_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+  void build_current_trie(Vector<T> &keys, Vector<uint32_t> *terminals,
                           const Config &config, std::size_t trie_id);
   template <typename T>
-  void build_next_trie(Vector<T> &keys, Vector<UInt32> *terminals,
+  void build_next_trie(Vector<T> &keys, Vector<uint32_t> *terminals,
                        const Config &config, std::size_t trie_id);
   template <typename T>
-  void build_terminals(const Vector<T> &keys, Vector<UInt32> *terminals) const;
+  void build_terminals(const Vector<T> &keys,
+                       Vector<uint32_t> *terminals) const;
 
   void reserve_cache(const Config &config, std::size_t trie_id,
                      std::size_t num_keys);

--- a/lib/marisa/grimoire/trie/range.h
+++ b/lib/marisa/grimoire/trie/range.h
@@ -13,15 +13,15 @@ class Range {
 
   void set_begin(std::size_t begin) {
     assert(begin <= UINT32_MAX);
-    begin_ = static_cast<UInt32>(begin);
+    begin_ = static_cast<uint32_t>(begin);
   }
   void set_end(std::size_t end) {
     assert(end <= UINT32_MAX);
-    end_ = static_cast<UInt32>(end);
+    end_ = static_cast<uint32_t>(end);
   }
   void set_key_pos(std::size_t key_pos) {
     assert(key_pos <= UINT32_MAX);
-    key_pos_ = static_cast<UInt32>(key_pos);
+    key_pos_ = static_cast<uint32_t>(key_pos);
   }
 
   std::size_t begin() const {
@@ -35,9 +35,9 @@ class Range {
   }
 
  private:
-  UInt32 begin_ = 0;
-  UInt32 end_ = 0;
-  UInt32 key_pos_ = 0;
+  uint32_t begin_ = 0;
+  uint32_t end_ = 0;
+  uint32_t key_pos_ = 0;
 };
 
 inline Range make_range(std::size_t begin, std::size_t end,

--- a/lib/marisa/grimoire/trie/state.h
+++ b/lib/marisa/grimoire/trie/state.h
@@ -29,15 +29,15 @@ class State {
 
   void set_node_id(std::size_t node_id) {
     assert(node_id <= UINT32_MAX);
-    node_id_ = static_cast<UInt32>(node_id);
+    node_id_ = static_cast<uint32_t>(node_id);
   }
   void set_query_pos(std::size_t query_pos) {
     assert(query_pos <= UINT32_MAX);
-    query_pos_ = static_cast<UInt32>(query_pos);
+    query_pos_ = static_cast<uint32_t>(query_pos);
   }
   void set_history_pos(std::size_t history_pos) {
     assert(history_pos <= UINT32_MAX);
-    history_pos_ = static_cast<UInt32>(history_pos);
+    history_pos_ = static_cast<uint32_t>(history_pos);
   }
   void set_status_code(StatusCode status_code) {
     status_code_ = status_code;
@@ -103,9 +103,9 @@ class State {
  private:
   std::vector<char> key_buf_;
   std::vector<History> history_;
-  UInt32 node_id_ = 0;
-  UInt32 query_pos_ = 0;
-  UInt32 history_pos_ = 0;
+  uint32_t node_id_ = 0;
+  uint32_t query_pos_ = 0;
+  uint32_t history_pos_ = 0;
   StatusCode status_code_ = MARISA_READY_TO_ALL;
 };
 

--- a/lib/marisa/grimoire/trie/tail.cc
+++ b/lib/marisa/grimoire/trie/tail.cc
@@ -10,7 +10,7 @@ namespace marisa::grimoire::trie {
 
 Tail::Tail() = default;
 
-void Tail::build(Vector<Entry> &entries, Vector<UInt32> *offsets,
+void Tail::build(Vector<Entry> &entries, Vector<uint32_t> *offsets,
                  TailMode mode) {
   MARISA_THROW_IF(offsets == nullptr, std::invalid_argument);
 
@@ -154,14 +154,14 @@ void Tail::swap(Tail &rhs) noexcept {
   end_flags_.swap(rhs.end_flags_);
 }
 
-void Tail::build_(Vector<Entry> &entries, Vector<UInt32> *offsets,
+void Tail::build_(Vector<Entry> &entries, Vector<uint32_t> *offsets,
                   TailMode mode) {
   for (std::size_t i = 0; i < entries.size(); ++i) {
     entries[i].set_id(i);
   }
   algorithm::sort(entries.begin(), entries.end());
 
-  Vector<UInt32> temp_offsets;
+  Vector<uint32_t> temp_offsets;
   temp_offsets.resize(entries.size(), 0);
 
   const Entry dummy;
@@ -175,10 +175,10 @@ void Tail::build_(Vector<Entry> &entries, Vector<UInt32> *offsets,
       ++match;
     }
     if ((match == current.length()) && (last->length() != 0)) {
-      temp_offsets[current.id()] = static_cast<UInt32>(
+      temp_offsets[current.id()] = static_cast<uint32_t>(
           temp_offsets[last->id()] + (last->length() - match));
     } else {
-      temp_offsets[current.id()] = static_cast<UInt32>(buf_.size());
+      temp_offsets[current.id()] = static_cast<uint32_t>(buf_.size());
       for (std::size_t j = 1; j <= current.length(); ++j) {
         buf_.push_back(current[current.length() - j]);
       }

--- a/lib/marisa/grimoire/trie/tail.h
+++ b/lib/marisa/grimoire/trie/tail.h
@@ -16,7 +16,7 @@ class Tail {
   Tail(const Tail &) = delete;
   Tail &operator=(const Tail &) = delete;
 
-  void build(Vector<Entry> &entries, Vector<UInt32> *offsets, TailMode mode);
+  void build(Vector<Entry> &entries, Vector<uint32_t> *offsets, TailMode mode);
 
   void map(Mapper &mapper);
   void read(Reader &reader);
@@ -55,7 +55,7 @@ class Tail {
   Vector<char> buf_;
   BitVector end_flags_;
 
-  void build_(Vector<Entry> &entries, Vector<UInt32> *offsets, TailMode mode);
+  void build_(Vector<Entry> &entries, Vector<uint32_t> *offsets, TailMode mode);
 
   void map_(Mapper &mapper);
   void read_(Reader &reader);

--- a/lib/marisa/grimoire/vector/bit-vector.h
+++ b/lib/marisa/grimoire/vector/bit-vector.h
@@ -12,9 +12,9 @@ namespace marisa::grimoire::vector {
 class BitVector {
  public:
 #if MARISA_WORD_SIZE == 64
-  using Unit = UInt64;
+  using Unit = uint64_t;
 #else   // MARISA_WORD_SIZE == 64
-  using Unit = UInt32;
+  using Unit = uint32_t;
 #endif  // MARISA_WORD_SIZE == 64
 
   BitVector() = default;
@@ -97,7 +97,7 @@ class BitVector {
            select1s_.total_size();
   }
   std::size_t io_size() const {
-    return units_.io_size() + (sizeof(UInt32) * 2) + ranks_.io_size() +
+    return units_.io_size() + (sizeof(uint32_t) * 2) + ranks_.io_size() +
            select0s_.io_size() + select1s_.io_size();
   }
 
@@ -118,8 +118,8 @@ class BitVector {
   std::size_t size_ = 0;
   std::size_t num_1s_ = 0;
   Vector<RankIndex> ranks_;
-  Vector<UInt32> select0s_;
-  Vector<UInt32> select1s_;
+  Vector<uint32_t> select0s_;
+  Vector<uint32_t> select1s_;
 
   void build_index(const BitVector &bv, bool enables_select0,
                    bool enables_select1);
@@ -127,12 +127,12 @@ class BitVector {
   void map_(Mapper &mapper) {
     units_.map(mapper);
     {
-      UInt32 temp_size;
+      uint32_t temp_size;
       mapper.map(&temp_size);
       size_ = temp_size;
     }
     {
-      UInt32 temp_num_1s;
+      uint32_t temp_num_1s;
       mapper.map(&temp_num_1s);
       MARISA_THROW_IF(temp_num_1s > size_, std::runtime_error);
       num_1s_ = temp_num_1s;
@@ -145,12 +145,12 @@ class BitVector {
   void read_(Reader &reader) {
     units_.read(reader);
     {
-      UInt32 temp_size;
+      uint32_t temp_size;
       reader.read(&temp_size);
       size_ = temp_size;
     }
     {
-      UInt32 temp_num_1s;
+      uint32_t temp_num_1s;
       reader.read(&temp_num_1s);
       MARISA_THROW_IF(temp_num_1s > size_, std::runtime_error);
       num_1s_ = temp_num_1s;
@@ -162,8 +162,8 @@ class BitVector {
 
   void write_(Writer &writer) const {
     units_.write(writer);
-    writer.write(static_cast<UInt32>(size_));
-    writer.write(static_cast<UInt32>(num_1s_));
+    writer.write(static_cast<uint32_t>(size_));
+    writer.write(static_cast<uint32_t>(num_1s_));
     ranks_.write(writer);
     select0s_.write(writer);
     select1s_.write(writer);

--- a/lib/marisa/grimoire/vector/flat-vector.h
+++ b/lib/marisa/grimoire/vector/flat-vector.h
@@ -11,9 +11,9 @@ namespace marisa::grimoire::vector {
 class FlatVector {
  public:
 #if MARISA_WORD_SIZE == 64
-  using Unit = UInt64;
+  using Unit = uint64_t;
 #else   // MARISA_WORD_SIZE == 64
-  using Unit = UInt32;
+  using Unit = uint32_t;
 #endif  // MARISA_WORD_SIZE == 64
 
   FlatVector() = default;
@@ -21,7 +21,7 @@ class FlatVector {
   FlatVector(const FlatVector &) = delete;
   FlatVector &operator=(const FlatVector &) = delete;
 
-  void build(const Vector<UInt32> &values) {
+  void build(const Vector<uint32_t> &values) {
     FlatVector temp;
     temp.build_(values);
     swap(temp);
@@ -41,7 +41,7 @@ class FlatVector {
     write_(writer);
   }
 
-  UInt32 operator[](std::size_t i) const {
+  uint32_t operator[](std::size_t i) const {
     assert(i < size_);
 
     const std::size_t pos = i * value_size_;
@@ -49,9 +49,9 @@ class FlatVector {
     const std::size_t unit_offset = pos % MARISA_WORD_SIZE;
 
     if ((unit_offset + value_size_) <= MARISA_WORD_SIZE) {
-      return static_cast<UInt32>(units_[unit_id] >> unit_offset) & mask_;
+      return static_cast<uint32_t>(units_[unit_id] >> unit_offset) & mask_;
     } else {
-      return static_cast<UInt32>(
+      return static_cast<uint32_t>(
                  (units_[unit_id] >> unit_offset) |
                  (units_[unit_id + 1] << (MARISA_WORD_SIZE - unit_offset))) &
              mask_;
@@ -61,7 +61,7 @@ class FlatVector {
   std::size_t value_size() const {
     return value_size_;
   }
-  UInt32 mask() const {
+  uint32_t mask() const {
     return mask_;
   }
 
@@ -75,7 +75,7 @@ class FlatVector {
     return units_.total_size();
   }
   std::size_t io_size() const {
-    return units_.io_size() + (sizeof(UInt32) * 2) + sizeof(UInt64);
+    return units_.io_size() + (sizeof(uint32_t) * 2) + sizeof(uint64_t);
   }
 
   void clear() noexcept {
@@ -91,11 +91,11 @@ class FlatVector {
  private:
   Vector<Unit> units_;
   std::size_t value_size_ = 0;
-  UInt32 mask_ = 0;
+  uint32_t mask_ = 0;
   std::size_t size_ = 0;
 
-  void build_(const Vector<UInt32> &values) {
-    UInt32 max_value = 0;
+  void build_(const Vector<uint32_t> &values) {
+    uint32_t max_value = 0;
     for (std::size_t i = 0; i < values.size(); ++i) {
       if (values[i] > max_value) {
         max_value = values[i];
@@ -111,7 +111,7 @@ class FlatVector {
     std::size_t num_units = values.empty() ? 0 : (64 / MARISA_WORD_SIZE);
     if (value_size != 0) {
       num_units = static_cast<std::size_t>(
-          ((static_cast<UInt64>(value_size) * values.size()) +
+          ((static_cast<uint64_t>(value_size) * values.size()) +
            (MARISA_WORD_SIZE - 1)) /
           MARISA_WORD_SIZE);
       num_units += num_units % (64 / MARISA_WORD_SIZE);
@@ -136,18 +136,18 @@ class FlatVector {
   void map_(Mapper &mapper) {
     units_.map(mapper);
     {
-      UInt32 temp_value_size;
+      uint32_t temp_value_size;
       mapper.map(&temp_value_size);
       MARISA_THROW_IF(temp_value_size > 32, std::runtime_error);
       value_size_ = temp_value_size;
     }
     {
-      UInt32 temp_mask;
+      uint32_t temp_mask;
       mapper.map(&temp_mask);
       mask_ = temp_mask;
     }
     {
-      UInt64 temp_size;
+      uint64_t temp_size;
       mapper.map(&temp_size);
       MARISA_THROW_IF(temp_size > SIZE_MAX, std::runtime_error);
       size_ = static_cast<std::size_t>(temp_size);
@@ -157,18 +157,18 @@ class FlatVector {
   void read_(Reader &reader) {
     units_.read(reader);
     {
-      UInt32 temp_value_size;
+      uint32_t temp_value_size;
       reader.read(&temp_value_size);
       MARISA_THROW_IF(temp_value_size > 32, std::runtime_error);
       value_size_ = temp_value_size;
     }
     {
-      UInt32 temp_mask;
+      uint32_t temp_mask;
       reader.read(&temp_mask);
       mask_ = temp_mask;
     }
     {
-      UInt64 temp_size;
+      uint64_t temp_size;
       reader.read(&temp_size);
       MARISA_THROW_IF(temp_size > SIZE_MAX, std::runtime_error);
       size_ = static_cast<std::size_t>(temp_size);
@@ -177,12 +177,12 @@ class FlatVector {
 
   void write_(Writer &writer) const {
     units_.write(writer);
-    writer.write(static_cast<UInt32>(value_size_));
-    writer.write(static_cast<UInt32>(mask_));
-    writer.write(static_cast<UInt64>(size_));
+    writer.write(static_cast<uint32_t>(value_size_));
+    writer.write(static_cast<uint32_t>(mask_));
+    writer.write(static_cast<uint64_t>(size_));
   }
 
-  void set(std::size_t i, UInt32 value) {
+  void set(std::size_t i, uint32_t value) {
     assert(i < size_);
     assert(value <= mask_);
 

--- a/lib/marisa/grimoire/vector/pop-count.h
+++ b/lib/marisa/grimoire/vector/pop-count.h
@@ -11,7 +11,7 @@ namespace marisa::grimoire::vector {
 
 #if defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L
 
-inline std::size_t popcount(UInt64 x) {
+inline std::size_t popcount(uint64_t x) {
   return static_cast<std::size_t>(std::popcount(x));
 }
 
@@ -25,7 +25,7 @@ inline std::size_t popcount(UInt64 x) {
 
  #if MARISA_WORD_SIZE == 64
 
-inline std::size_t popcount(UInt64 x) {
+inline std::size_t popcount(uint64_t x) {
   #if MARISA_HAS_BUILTIN(__builtin_popcountll)
   static_assert(sizeof(x) == sizeof(unsigned long long),
                 "__builtin_popcountll does not take 64-bit arg");
@@ -50,7 +50,7 @@ inline std::size_t popcount(UInt64 x) {
 
  #else  // MARISA_WORD_SIZE == 64
 
-inline std::size_t popcount(UInt32 x) {
+inline std::size_t popcount(uint32_t x) {
   #if MARISA_HAS_BUILTIN(__builtin_popcount)
   static_assert(sizeof(x) == sizeof(unsigned int),
                 "__builtin_popcount does not take 32-bit arg");

--- a/lib/marisa/grimoire/vector/rank-index.h
+++ b/lib/marisa/grimoire/vector/rank-index.h
@@ -13,40 +13,40 @@ class RankIndex {
 
   void set_abs(std::size_t value) {
     assert(value <= UINT32_MAX);
-    abs_ = static_cast<UInt32>(value);
+    abs_ = static_cast<uint32_t>(value);
   }
   void set_rel1(std::size_t value) {
     assert(value <= 64);
-    rel_lo_ = static_cast<UInt32>((rel_lo_ & ~0x7FU) | (value & 0x7FU));
+    rel_lo_ = static_cast<uint32_t>((rel_lo_ & ~0x7FU) | (value & 0x7FU));
   }
   void set_rel2(std::size_t value) {
     assert(value <= 128);
-    rel_lo_ =
-        static_cast<UInt32>((rel_lo_ & ~(0xFFU << 7)) | ((value & 0xFFU) << 7));
+    rel_lo_ = static_cast<uint32_t>((rel_lo_ & ~(0xFFU << 7)) |
+                                    ((value & 0xFFU) << 7));
   }
   void set_rel3(std::size_t value) {
     assert(value <= 192);
-    rel_lo_ = static_cast<UInt32>((rel_lo_ & ~(0xFFU << 15)) |
-                                  ((value & 0xFFU) << 15));
+    rel_lo_ = static_cast<uint32_t>((rel_lo_ & ~(0xFFU << 15)) |
+                                    ((value & 0xFFU) << 15));
   }
   void set_rel4(std::size_t value) {
     assert(value <= 256);
-    rel_lo_ = static_cast<UInt32>((rel_lo_ & ~(0x1FFU << 23)) |
-                                  ((value & 0x1FFU) << 23));
+    rel_lo_ = static_cast<uint32_t>((rel_lo_ & ~(0x1FFU << 23)) |
+                                    ((value & 0x1FFU) << 23));
   }
   void set_rel5(std::size_t value) {
     assert(value <= 320);
-    rel_hi_ = static_cast<UInt32>((rel_hi_ & ~0x1FFU) | (value & 0x1FFU));
+    rel_hi_ = static_cast<uint32_t>((rel_hi_ & ~0x1FFU) | (value & 0x1FFU));
   }
   void set_rel6(std::size_t value) {
     assert(value <= 384);
-    rel_hi_ = static_cast<UInt32>((rel_hi_ & ~(0x1FFU << 9)) |
-                                  ((value & 0x1FFU) << 9));
+    rel_hi_ = static_cast<uint32_t>((rel_hi_ & ~(0x1FFU << 9)) |
+                                    ((value & 0x1FFU) << 9));
   }
   void set_rel7(std::size_t value) {
     assert(value <= 448);
-    rel_hi_ = static_cast<UInt32>((rel_hi_ & ~(0x1FFU << 18)) |
-                                  ((value & 0x1FFU) << 18));
+    rel_hi_ = static_cast<uint32_t>((rel_hi_ & ~(0x1FFU << 18)) |
+                                    ((value & 0x1FFU) << 18));
   }
 
   std::size_t abs() const {
@@ -75,9 +75,9 @@ class RankIndex {
   }
 
  private:
-  UInt32 abs_ = 0;
-  UInt32 rel_lo_ = 0;
-  UInt32 rel_hi_ = 0;
+  uint32_t abs_ = 0;
+  uint32_t rel_lo_ = 0;
+  uint32_t rel_hi_ = 0;
 };
 
 }  // namespace marisa::grimoire::vector

--- a/lib/marisa/grimoire/vector/vector.h
+++ b/lib/marisa/grimoire/vector/vector.h
@@ -196,7 +196,7 @@ class Vector {
     return sizeof(T) * size_;
   }
   std::size_t io_size() const {
-    return sizeof(UInt64) + ((total_size() + 7) & ~0x07U);
+    return sizeof(uint64_t) + ((total_size() + 7) & ~0x07U);
   }
 
   void clear() noexcept {
@@ -224,7 +224,7 @@ class Vector {
   bool fixed_ = false;
 
   void map_(Mapper &mapper) {
-    UInt64 total_size;
+    uint64_t total_size;
     mapper.map(&total_size);
     MARISA_THROW_IF(total_size > SIZE_MAX, std::runtime_error);
     MARISA_THROW_IF((total_size % sizeof(T)) != 0, std::runtime_error);
@@ -235,7 +235,7 @@ class Vector {
     fix();
   }
   void read_(Reader &reader) {
-    UInt64 total_size;
+    uint64_t total_size;
     reader.read(&total_size);
     MARISA_THROW_IF(total_size > SIZE_MAX, std::runtime_error);
     MARISA_THROW_IF((total_size % sizeof(T)) != 0, std::runtime_error);
@@ -245,7 +245,7 @@ class Vector {
     reader.seek(static_cast<std::size_t>((8 - (total_size % 8)) % 8));
   }
   void write_(Writer &writer) const {
-    writer.write(static_cast<UInt64>(total_size()));
+    writer.write(static_cast<uint64_t>(total_size()));
     writer.write(const_objs_, size_);
     writer.seek((8 - (total_size() % 8)) % 8);
   }

--- a/tests/io-test.cc
+++ b/tests/io-test.cc
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cstdint>
 #include <exception>
 #include <sstream>
 #include <stdexcept>
@@ -24,8 +25,8 @@ void TestFilename() {
     marisa::grimoire::Writer writer;
     writer.open("io-test.dat");
 
-    writer.write(marisa::UInt32{123});
-    writer.write(marisa::UInt32{234});
+    writer.write(std::uint32_t{123});
+    writer.write(std::uint32_t{234});
 
     double values[] = {3.45, 4.56};
     writer.write(values, 2);
@@ -37,7 +38,7 @@ void TestFilename() {
     marisa::grimoire::Reader reader;
     reader.open("io-test.dat");
 
-    marisa::UInt32 value;
+    std::uint32_t value;
     reader.read(&value);
     ASSERT(value == 123);
     reader.read(&value);
@@ -56,7 +57,7 @@ void TestFilename() {
     marisa::grimoire::Mapper mapper;
     mapper.open("io-test.dat");
 
-    marisa::UInt32 value;
+    std::uint32_t value;
     mapper.map(&value);
     ASSERT(value == 123);
     mapper.map(&value);
@@ -75,7 +76,7 @@ void TestFilename() {
     marisa::grimoire::Mapper mapper;
     mapper.open("io-test.dat", MARISA_MAP_POPULATE);
 
-    marisa::UInt32 value;
+    std::uint32_t value;
     mapper.map(&value);
     ASSERT(value == 123);
     mapper.map(&value);
@@ -122,7 +123,7 @@ void TestFd() {
     marisa::grimoire::Writer writer;
     writer.open(fd);
 
-    marisa::UInt32 value = 234;
+    std::uint32_t value = 234;
     writer.write(value);
 
     double values[] = {34.5, 67.8};
@@ -147,7 +148,7 @@ void TestFd() {
     marisa::grimoire::Reader reader;
     reader.open(fd);
 
-    marisa::UInt32 value;
+    std::uint32_t value;
     reader.read(&value);
     ASSERT(value == 234);
 
@@ -183,7 +184,7 @@ void TestFile() {
     marisa::grimoire::Writer writer;
     writer.open(file);
 
-    marisa::UInt32 value = 10;
+    std::uint32_t value = 10;
     writer.write(value);
 
     double values[2] = {0.1, 0.2};
@@ -203,7 +204,7 @@ void TestFile() {
     marisa::grimoire::Reader reader;
     reader.open(file);
 
-    marisa::UInt32 value;
+    std::uint32_t value;
     reader.read(&value);
     ASSERT(value == 10);
 
@@ -230,7 +231,7 @@ void TestStream() {
     marisa::grimoire::Writer writer;
     writer.open(stream);
 
-    marisa::UInt32 value = 12;
+    std::uint32_t value = 12;
     writer.write(value);
 
     double values[2] = {3.4, 5.6};
@@ -241,7 +242,7 @@ void TestStream() {
     marisa::grimoire::Reader reader;
     reader.open(stream);
 
-    marisa::UInt32 value;
+    std::uint32_t value;
     reader.read(&value);
     ASSERT(value == 12);
 

--- a/tests/trie-test.cc
+++ b/tests/trie-test.cc
@@ -6,6 +6,7 @@
 #include <marisa/grimoire/trie/tail.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <sstream>
@@ -232,14 +233,14 @@ void TestTextTail() {
 
   marisa::grimoire::trie::Tail tail;
   marisa::grimoire::Vector<marisa::grimoire::trie::Entry> entries;
-  marisa::grimoire::Vector<marisa::UInt32> offsets;
+  marisa::grimoire::Vector<std::uint32_t> offsets;
   tail.build(entries, &offsets, MARISA_TEXT_TAIL);
 
   ASSERT(tail.mode() == MARISA_TEXT_TAIL);
   ASSERT(tail.size() == 0);
   ASSERT(tail.empty());
   ASSERT(tail.total_size() == tail.size());
-  ASSERT(tail.io_size() == (sizeof(marisa::UInt64) * 6));
+  ASSERT(tail.io_size() == (sizeof(std::uint64_t) * 6));
 
   ASSERT(offsets.empty());
 
@@ -253,7 +254,7 @@ void TestTextTail() {
   ASSERT(tail.size() == 2);
   ASSERT(!tail.empty());
   ASSERT(tail.total_size() == tail.size());
-  ASSERT(tail.io_size() == (sizeof(marisa::UInt64) * 7));
+  ASSERT(tail.io_size() == (sizeof(std::uint64_t) * 7));
 
   ASSERT(offsets.size() == entries.size());
   ASSERT(offsets[0] == 0);
@@ -353,14 +354,14 @@ void TestBinaryTail() {
 
   marisa::grimoire::trie::Tail tail;
   marisa::grimoire::Vector<marisa::grimoire::trie::Entry> entries;
-  marisa::grimoire::Vector<marisa::UInt32> offsets;
+  marisa::grimoire::Vector<std::uint32_t> offsets;
   tail.build(entries, &offsets, MARISA_BINARY_TAIL);
 
   ASSERT(tail.mode() == MARISA_TEXT_TAIL);
   ASSERT(tail.size() == 0);
   ASSERT(tail.empty());
   ASSERT(tail.total_size() == tail.size());
-  ASSERT(tail.io_size() == (sizeof(marisa::UInt64) * 6));
+  ASSERT(tail.io_size() == (sizeof(std::uint64_t) * 6));
 
   ASSERT(offsets.empty());
 
@@ -373,8 +374,8 @@ void TestBinaryTail() {
   ASSERT(tail.mode() == MARISA_BINARY_TAIL);
   ASSERT(tail.size() == 1);
   ASSERT(!tail.empty());
-  ASSERT(tail.total_size() == (tail.size() + sizeof(marisa::UInt64)));
-  ASSERT(tail.io_size() == (sizeof(marisa::UInt64) * 8));
+  ASSERT(tail.total_size() == (tail.size() + sizeof(std::uint64_t)));
+  ASSERT(tail.io_size() == (sizeof(std::uint64_t) * 8));
 
   ASSERT(offsets.size() == entries.size());
   ASSERT(offsets[0] == 0);

--- a/tests/vector-test.cc
+++ b/tests/vector-test.cc
@@ -2,6 +2,7 @@
 #include <marisa/grimoire/vector/pop-count.h>
 #include <marisa/grimoire/vector/rank-index.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <exception>
@@ -93,7 +94,7 @@ void TestVector() {
   ASSERT(!vec.fixed());
   ASSERT(vec.empty());
   ASSERT(vec.total_size() == 0);
-  ASSERT(vec.io_size() == sizeof(marisa::UInt64));
+  ASSERT(vec.io_size() == sizeof(std::uint64_t));
 
   for (std::size_t i = 0; i < values.size(); ++i) {
     vec.push_back(values[i]);
@@ -107,7 +108,7 @@ void TestVector() {
   ASSERT(!vec.empty());
   ASSERT(vec.total_size() == (sizeof(int) * values.size()));
   ASSERT(vec.io_size() ==
-         sizeof(marisa::UInt64) + ((sizeof(int) * values.size())));
+         sizeof(std::uint64_t) + ((sizeof(int) * values.size())));
 
   ASSERT(static_cast<const marisa::grimoire::Vector<int> &>(vec).front() ==
          values.front());
@@ -147,7 +148,7 @@ void TestVector() {
     ASSERT(!vec.empty());
     ASSERT(vec.total_size() == (sizeof(int) * values.size()));
     ASSERT(vec.io_size() ==
-           sizeof(marisa::UInt64) + ((sizeof(int) * values.size())));
+           sizeof(std::uint64_t) + ((sizeof(int) * values.size())));
 
     for (std::size_t i = 0; i < values.size(); ++i) {
       ASSERT(static_cast<const marisa::grimoire::Vector<int> &>(vec)[i] ==
@@ -169,7 +170,7 @@ void TestVector() {
   ASSERT(!vec.empty());
   ASSERT(vec.total_size() == (sizeof(int) * values.size()));
   ASSERT(vec.io_size() ==
-         sizeof(marisa::UInt64) + ((sizeof(int) * values.size())));
+         sizeof(std::uint64_t) + ((sizeof(int) * values.size())));
 
   for (std::size_t i = 0; i < values.size(); ++i) {
     ASSERT(vec[i] == values[i]);
@@ -207,9 +208,9 @@ void TestFlatVector() {
   ASSERT(vec.size() == 0);
   ASSERT(vec.empty());
   ASSERT(vec.total_size() == 0);
-  ASSERT(vec.io_size() == (sizeof(marisa::UInt64) * 3));
+  ASSERT(vec.io_size() == (sizeof(std::uint64_t) * 3));
 
-  marisa::grimoire::Vector<marisa::UInt32> values;
+  marisa::grimoire::Vector<std::uint32_t> values;
   vec.build(values);
 
   ASSERT(vec.value_size() == 0);
@@ -217,7 +218,7 @@ void TestFlatVector() {
   ASSERT(vec.size() == 0);
   ASSERT(vec.empty());
   ASSERT(vec.total_size() == 0);
-  ASSERT(vec.io_size() == (sizeof(marisa::UInt64) * 3));
+  ASSERT(vec.io_size() == (sizeof(std::uint64_t) * 3));
 
   values.push_back(0);
   vec.build(values);
@@ -227,7 +228,7 @@ void TestFlatVector() {
   ASSERT(vec.size() == 1);
   ASSERT(!vec.empty());
   ASSERT(vec.total_size() == 8);
-  ASSERT(vec.io_size() == (sizeof(marisa::UInt64) * 4));
+  ASSERT(vec.io_size() == (sizeof(std::uint64_t) * 4));
   ASSERT(vec[0] == 0);
 
   values.push_back(255);
@@ -291,7 +292,7 @@ void TestFlatVector() {
 
   values.clear();
   for (std::size_t i = 0; i < 10000; ++i) {
-    values.push_back(static_cast<marisa::UInt32>(random_engine()));
+    values.push_back(static_cast<std::uint32_t>(random_engine()));
   }
   vec.build(values);
 
@@ -309,7 +310,7 @@ void TestBitVector(std::size_t size) {
   ASSERT(bv.size() == 0);
   ASSERT(bv.empty());
   ASSERT(bv.total_size() == 0);
-  ASSERT(bv.io_size() == sizeof(marisa::UInt64) * 5);
+  ASSERT(bv.io_size() == sizeof(std::uint64_t) * 5);
 
   std::vector<bool> bits(size);
   std::vector<std::size_t> zeros, ones;
@@ -354,7 +355,7 @@ void TestBitVector(std::size_t size) {
   ASSERT(bv.size() == 0);
   ASSERT(bv.empty());
   ASSERT(bv.total_size() == 0);
-  ASSERT(bv.io_size() == sizeof(marisa::UInt64) * 5);
+  ASSERT(bv.io_size() == sizeof(std::uint64_t) * 5);
 
   {
     marisa::grimoire::Reader reader;


### PR DESCRIPTION
These changes were proposed as a part of #110.

UIntXX were added because an ancient VC++ didn't provide uintXX_t.
The latest VC++ provides uintXX_t and we don't need UIntXX anymore.
