### PR TITLE
Change key IDs in the public API to a type alias

### DIFF
--- a/bindings/marisa-swig-python3.cxx
+++ b/bindings/marisa-swig-python3.cxx
@@ -10,7 +10,7 @@ void Key::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = key_.length();
 }
 
-size_t Key::key_id() const {
+marisa_key_t Key::key_id() const {
   return key_.id();
 }
 
@@ -23,7 +23,7 @@ void Query::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = query_.length();
 }
 
-size_t Query::query_id() const {
+marisa_key_t Query::query_id() const {
   return query_.id();
 }
 
@@ -52,7 +52,7 @@ void Keyset::key_str(size_t i,
   *length_out = (*keyset_)[i].length();
 }
 
-size_t Keyset::key_id(size_t i) const {
+marisa_key_t Keyset::key_id(size_t i) const {
   return (*keyset_)[i].id();
 }
 
@@ -108,7 +108,7 @@ void Agent::set_query(const char *ptr, size_t length) {
   agent_->set_query(buf_, length);
 }
 
-void Agent::set_query(size_t id) {
+void Agent::set_query(marisa_key_t id) {
   agent_->set_query(id);
 }
 
@@ -125,7 +125,7 @@ void Agent::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->key().length();
 }
 
-size_t Agent::key_id() const {
+marisa_key_t Agent::key_id() const {
   return agent_->key().id();
 }
 
@@ -134,7 +134,7 @@ void Agent::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->query().length();
 }
 
-size_t Agent::query_id() const {
+marisa_key_t Agent::query_id() const {
   return agent_->query().id();
 }
 
@@ -177,7 +177,7 @@ bool Trie::predictive_search(Agent &agent) const {
   return trie_->predictive_search(*agent.agent_);
 }
 
-size_t Trie::lookup(const char *ptr, size_t length) const {
+marisa_key_t Trie::lookup(const char *ptr, size_t length) const {
   marisa::Agent agent;
   agent.set_query(ptr, length);
   if (!trie_->lookup(agent)) {
@@ -186,7 +186,7 @@ size_t Trie::lookup(const char *ptr, size_t length) const {
   return agent.key().id();
 }
 
-void Trie::reverse_lookup(size_t id,
+void Trie::reverse_lookup(marisa_key_t id,
     const char **ptr_out_to_be_deleted, size_t *length_out) const {
   marisa::Agent agent;
   agent.set_query(id);

--- a/bindings/marisa-swig-python3.h
+++ b/bindings/marisa-swig-python3.h
@@ -57,7 +57,7 @@ enum NodeOrder {
 class Key {
  public:
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
   float weight() const;
 
  private:
@@ -71,7 +71,7 @@ class Key {
 class Query {
  public:
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   const marisa::Query query_;
@@ -95,7 +95,7 @@ class Keyset {
 
   void key_str(std::size_t i,
       const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id(std::size_t i) const;
+  marisa_key_t key_id(std::size_t i) const;
 
   std::size_t num_keys() const;
 
@@ -121,16 +121,16 @@ class Agent {
   ~Agent();
 
   void set_query(const char *ptr, std::size_t length);
-  void set_query(std::size_t id);
+  void set_query(marisa_key_t id);
 
   const Key &key() const;
   const Query &query() const;
 
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
 
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   marisa::Agent *agent_;
@@ -157,8 +157,8 @@ class Trie {
   bool common_prefix_search(Agent &agent) const;
   bool predictive_search(Agent &agent) const;
 
-  std::size_t lookup(const char *ptr, std::size_t length) const;
-  void reverse_lookup(std::size_t id,
+  marisa_key_t lookup(const char *ptr, std::size_t length) const;
+  void reverse_lookup(marisa_key_t id,
       const char **ptr_out_to_be_deleted, std::size_t *length_out) const;
 
   std::size_t num_tries() const;

--- a/bindings/marisa-swig.cxx
+++ b/bindings/marisa-swig.cxx
@@ -10,7 +10,7 @@ void Key::str(const char **ptr_out, size_t *length_out) const {
   *length_out = key_.length();
 }
 
-size_t Key::id() const {
+marisa_key_t Key::id() const {
   return key_.id();
 }
 
@@ -23,7 +23,7 @@ void Query::str(const char **ptr_out, size_t *length_out) const {
   *length_out = query_.length();
 }
 
-size_t Query::id() const {
+marisa_key_t Query::id() const {
   return query_.id();
 }
 
@@ -52,7 +52,7 @@ void Keyset::key_str(size_t i,
   *length_out = (*keyset_)[i].length();
 }
 
-size_t Keyset::key_id(size_t i) const {
+marisa_key_t Keyset::key_id(size_t i) const {
   return (*keyset_)[i].id();
 }
 
@@ -108,7 +108,7 @@ void Agent::set_query(const char *ptr, size_t length) {
   agent_->set_query(buf_, length);
 }
 
-void Agent::set_query(size_t id) {
+void Agent::set_query(marisa_key_t id) {
   agent_->set_query(id);
 }
 
@@ -125,7 +125,7 @@ void Agent::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->key().length();
 }
 
-size_t Agent::key_id() const {
+marisa_key_t Agent::key_id() const {
   return agent_->key().id();
 }
 
@@ -134,7 +134,7 @@ void Agent::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->query().length();
 }
 
-size_t Agent::query_id() const {
+marisa_key_t Agent::query_id() const {
   return agent_->query().id();
 }
 
@@ -177,7 +177,7 @@ bool Trie::predictive_search(Agent &agent) const {
   return trie_->predictive_search(*agent.agent_);
 }
 
-size_t Trie::lookup(const char *ptr, size_t length) const {
+marisa_key_t Trie::lookup(const char *ptr, size_t length) const {
   marisa::Agent agent;
   agent.set_query(ptr, length);
   if (!trie_->lookup(agent)) {
@@ -186,7 +186,7 @@ size_t Trie::lookup(const char *ptr, size_t length) const {
   return agent.key().id();
 }
 
-void Trie::reverse_lookup(size_t id,
+void Trie::reverse_lookup(marisa_key_t id,
     const char **ptr_out_to_be_deleted, size_t *length_out) const {
   marisa::Agent agent;
   agent.set_query(id);

--- a/bindings/marisa-swig.h
+++ b/bindings/marisa-swig.h
@@ -57,7 +57,7 @@ enum NodeOrder {
 class Key {
  public:
   void str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t id() const;
+  marisa_key_t id() const;
   float weight() const;
 
  private:
@@ -71,7 +71,7 @@ class Key {
 class Query {
  public:
   void str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t id() const;
+  marisa_key_t id() const;
 
  private:
   const marisa::Query query_;
@@ -95,7 +95,7 @@ class Keyset {
 
   void key_str(std::size_t i,
       const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id(std::size_t i) const;
+  marisa_key_t key_id(size_t i) const;
 
   std::size_t num_keys() const;
 
@@ -121,16 +121,16 @@ class Agent {
   ~Agent();
 
   void set_query(const char *ptr, std::size_t length);
-  void set_query(std::size_t id);
+  void set_query(marisa_key_t id);
 
   const Key &key() const;
   const Query &query() const;
 
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
 
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   marisa::Agent *agent_;
@@ -157,8 +157,8 @@ class Trie {
   bool common_prefix_search(Agent &agent) const;
   bool predictive_search(Agent &agent) const;
 
-  std::size_t lookup(const char *ptr, std::size_t length) const;
-  void reverse_lookup(std::size_t id,
+  marisa_key_t lookup(const char *ptr, std::size_t length) const;
+  void reverse_lookup(marisa_key_t id,
       const char **ptr_out_to_be_deleted, std::size_t *length_out) const;
 
   std::size_t num_tries() const;

--- a/bindings/perl/marisa-swig.cxx
+++ b/bindings/perl/marisa-swig.cxx
@@ -10,7 +10,7 @@ void Key::str(const char **ptr_out, size_t *length_out) const {
   *length_out = key_.length();
 }
 
-size_t Key::id() const {
+marisa_key_t Key::id() const {
   return key_.id();
 }
 
@@ -23,7 +23,7 @@ void Query::str(const char **ptr_out, size_t *length_out) const {
   *length_out = query_.length();
 }
 
-size_t Query::id() const {
+marisa_key_t Query::id() const {
   return query_.id();
 }
 
@@ -52,7 +52,7 @@ void Keyset::key_str(size_t i,
   *length_out = (*keyset_)[i].length();
 }
 
-size_t Keyset::key_id(size_t i) const {
+marisa_key_t Keyset::key_id(size_t i) const {
   return (*keyset_)[i].id();
 }
 
@@ -108,7 +108,7 @@ void Agent::set_query(const char *ptr, size_t length) {
   agent_->set_query(buf_, length);
 }
 
-void Agent::set_query(size_t id) {
+void Agent::set_query(marisa_key_t id) {
   agent_->set_query(id);
 }
 
@@ -125,7 +125,7 @@ void Agent::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->key().length();
 }
 
-size_t Agent::key_id() const {
+marisa_key_t Agent::key_id() const {
   return agent_->key().id();
 }
 
@@ -134,7 +134,7 @@ void Agent::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->query().length();
 }
 
-size_t Agent::query_id() const {
+marisa_key_t Agent::query_id() const {
   return agent_->query().id();
 }
 
@@ -177,7 +177,7 @@ bool Trie::predictive_search(Agent &agent) const {
   return trie_->predictive_search(*agent.agent_);
 }
 
-size_t Trie::lookup(const char *ptr, size_t length) const {
+marisa_key_t Trie::lookup(const char *ptr, size_t length) const {
   marisa::Agent agent;
   agent.set_query(ptr, length);
   if (!trie_->lookup(agent)) {
@@ -186,7 +186,7 @@ size_t Trie::lookup(const char *ptr, size_t length) const {
   return agent.key().id();
 }
 
-void Trie::reverse_lookup(size_t id,
+void Trie::reverse_lookup(marisa_key_t id,
     const char **ptr_out_to_be_deleted, size_t *length_out) const {
   marisa::Agent agent;
   agent.set_query(id);

--- a/bindings/perl/marisa-swig.h
+++ b/bindings/perl/marisa-swig.h
@@ -57,7 +57,7 @@ enum NodeOrder {
 class Key {
  public:
   void str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t id() const;
+  marisa_key_t id() const;
   float weight() const;
 
  private:
@@ -71,7 +71,7 @@ class Key {
 class Query {
  public:
   void str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t id() const;
+  marisa_key_t id() const;
 
  private:
   const marisa::Query query_;
@@ -95,7 +95,7 @@ class Keyset {
 
   void key_str(std::size_t i,
       const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id(std::size_t i) const;
+  marisa_key_t key_id(size_t i) const;
 
   std::size_t num_keys() const;
 
@@ -121,16 +121,16 @@ class Agent {
   ~Agent();
 
   void set_query(const char *ptr, std::size_t length);
-  void set_query(std::size_t id);
+  void set_query(marisa_key_t id);
 
   const Key &key() const;
   const Query &query() const;
 
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
 
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   marisa::Agent *agent_;
@@ -157,8 +157,8 @@ class Trie {
   bool common_prefix_search(Agent &agent) const;
   bool predictive_search(Agent &agent) const;
 
-  std::size_t lookup(const char *ptr, std::size_t length) const;
-  void reverse_lookup(std::size_t id,
+  marisa_key_t lookup(const char *ptr, std::size_t length) const;
+  void reverse_lookup(marisa_key_t id,
       const char **ptr_out_to_be_deleted, std::size_t *length_out) const;
 
   std::size_t num_tries() const;

--- a/bindings/perl/marisa-swig_wrap.cxx
+++ b/bindings/perl/marisa-swig_wrap.cxx
@@ -1512,15 +1512,16 @@ SWIG_Perl_SetModule(swig_module_info *module) {
 
 #define SWIGTYPE_p_char swig_types[0]
 #define SWIGTYPE_p_marisa__Key swig_types[1]
-#define SWIGTYPE_p_marisa_swig__Agent swig_types[2]
-#define SWIGTYPE_p_marisa_swig__Key swig_types[3]
-#define SWIGTYPE_p_marisa_swig__Keyset swig_types[4]
-#define SWIGTYPE_p_marisa_swig__Query swig_types[5]
-#define SWIGTYPE_p_marisa_swig__Trie swig_types[6]
-#define SWIGTYPE_p_p_char swig_types[7]
-#define SWIGTYPE_p_std__size_t swig_types[8]
-static swig_type_info *swig_types[10];
-static swig_module_info swig_module = {swig_types, 9, 0, 0, 0, 0};
+#define SWIGTYPE_p_marisa_key_t swig_types[2]
+#define SWIGTYPE_p_marisa_swig__Agent swig_types[3]
+#define SWIGTYPE_p_marisa_swig__Key swig_types[4]
+#define SWIGTYPE_p_marisa_swig__Keyset swig_types[5]
+#define SWIGTYPE_p_marisa_swig__Query swig_types[6]
+#define SWIGTYPE_p_marisa_swig__Trie swig_types[7]
+#define SWIGTYPE_p_p_char swig_types[8]
+#define SWIGTYPE_p_std__size_t swig_types[9]
+static swig_type_info *swig_types[11];
+static swig_module_info swig_module = {swig_types, 10, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -1628,75 +1629,6 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
     sv_setsv(obj, &PL_sv_undef);
   }
   return obj;
-}
-
-
-SWIGINTERNINLINE SV *
-SWIG_From_unsigned_SS_long  SWIG_PERL_DECL_ARGS_1(unsigned long value)
-{
-  SV *sv;
-  if (UVSIZE >= sizeof(value) || value <= UV_MAX)
-    sv = newSVuv(value);
-  else
-    sv = newSVpvf("%lu", value);
-  return sv_2mortal(sv);
-}
-
-
-#include <limits.h>
-#if !defined(SWIG_NO_LLONG_MAX)
-# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
-#   define LLONG_MAX __LONG_LONG_MAX__
-#   define LLONG_MIN (-LLONG_MAX - 1LL)
-#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
-# endif
-#endif
-
-
-#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
-#  define SWIG_LONG_LONG_AVAILABLE
-#endif
-
-
-#include <stdio.h>
-#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__BORLANDC__) || defined(_WATCOM)
-# ifndef snprintf
-#  define snprintf _snprintf
-# endif
-#endif
-
-
-#ifdef SWIG_LONG_LONG_AVAILABLE
-SWIGINTERNINLINE SV *
-SWIG_From_unsigned_SS_long_SS_long  SWIG_PERL_DECL_ARGS_1(unsigned long long value)
-{
-  SV *sv;
-  if (UVSIZE >= sizeof(value) || value <= UV_MAX)
-    sv = newSVuv((UV)(value));
-  else {
-    //sv = newSVpvf("%llu", value); doesn't work in non 64bit Perl
-    char temp[256];
-    SWIG_snprintf(temp, sizeof(temp), "%llu", value);
-    sv = newSVpv(temp, 0);
-  }
-  return sv_2mortal(sv);
-}
-#endif
-
-
-SWIGINTERNINLINE SV *
-SWIG_From_size_t  SWIG_PERL_DECL_ARGS_1(size_t value)
-{    
-#ifdef SWIG_LONG_LONG_AVAILABLE
-  if (sizeof(size_t) <= sizeof(unsigned long)) {
-#endif
-    return SWIG_From_unsigned_SS_long  SWIG_PERL_CALL_ARGS_1(static_cast< unsigned long >(value));
-#ifdef SWIG_LONG_LONG_AVAILABLE
-  } else {
-    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
-    return SWIG_From_unsigned_SS_long_SS_long  SWIG_PERL_CALL_ARGS_1(static_cast< unsigned long long >(value));
-  }
-#endif
 }
 
 
@@ -1863,6 +1795,16 @@ SWIG_AsVal_float SWIG_PERL_DECL_ARGS_2(SV * obj, float *val)
 
 
 
+#include <limits.h>
+#if !defined(SWIG_NO_LLONG_MAX)
+# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
+#   define LLONG_MAX __LONG_LONG_MAX__
+#   define LLONG_MIN (-LLONG_MAX - 1LL)
+#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
+# endif
+#endif
+
+
 #include <stdlib.h>
 #ifdef _MSC_VER
 # ifndef strtoull
@@ -1954,6 +1896,11 @@ SWIG_AsVal_unsigned_SS_long SWIG_PERL_DECL_ARGS_2(SV *obj, unsigned long *val)
 }
 
 
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
 #ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_unsigned_SS_long_SS_long SWIG_PERL_DECL_ARGS_2(SV *obj, unsigned long long *val)
@@ -2022,6 +1969,60 @@ SWIG_AsVal_size_t SWIG_PERL_DECL_ARGS_2(SV * obj, size_t *val)
   }
 #endif
   return res;
+}
+
+
+SWIGINTERNINLINE SV *
+SWIG_From_unsigned_SS_long  SWIG_PERL_DECL_ARGS_1(unsigned long value)
+{
+  SV *sv;
+  if (UVSIZE >= sizeof(value) || value <= UV_MAX)
+    sv = newSVuv(value);
+  else
+    sv = newSVpvf("%lu", value);
+  return sv_2mortal(sv);
+}
+
+
+#include <stdio.h>
+#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__BORLANDC__) || defined(_WATCOM)
+# ifndef snprintf
+#  define snprintf _snprintf
+# endif
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERNINLINE SV *
+SWIG_From_unsigned_SS_long_SS_long  SWIG_PERL_DECL_ARGS_1(unsigned long long value)
+{
+  SV *sv;
+  if (UVSIZE >= sizeof(value) || value <= UV_MAX)
+    sv = newSVuv((UV)(value));
+  else {
+    //sv = newSVpvf("%llu", value); doesn't work in non 64bit Perl
+    char temp[256];
+    SWIG_snprintf(temp, sizeof(temp), "%llu", value);
+    sv = newSVpv(temp, 0);
+  }
+  return sv_2mortal(sv);
+}
+#endif
+
+
+SWIGINTERNINLINE SV *
+SWIG_From_size_t  SWIG_PERL_DECL_ARGS_1(size_t value)
+{    
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    return SWIG_From_unsigned_SS_long  SWIG_PERL_CALL_ARGS_1(static_cast< unsigned long >(value));
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else {
+    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
+    return SWIG_From_unsigned_SS_long_SS_long  SWIG_PERL_CALL_ARGS_1(static_cast< unsigned long long >(value));
+  }
+#endif
 }
 
 
@@ -2167,7 +2168,7 @@ XS(_wrap_Key_id) {
     void *argp1 = 0 ;
     int res1 = 0 ;
     int argvi = 0;
-    std::size_t result;
+    marisa_key_t result;
     dXSARGS;
     
     if ((items < 1) || (items > 1)) {
@@ -2187,7 +2188,7 @@ XS(_wrap_Key_id) {
         SWIG_exception(SWIG_UnknownError,"Unknown exception");
       }
     }
-    ST(argvi) = SWIG_From_size_t  SWIG_PERL_CALL_ARGS_1(static_cast< size_t >(result)); argvi++ ;
+    ST(argvi) = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN | 0); argvi++ ;
     
     XSRETURN(argvi);
   fail:
@@ -2322,7 +2323,7 @@ XS(_wrap_Query_id) {
     void *argp1 = 0 ;
     int res1 = 0 ;
     int argvi = 0;
-    std::size_t result;
+    marisa_key_t result;
     dXSARGS;
     
     if ((items < 1) || (items > 1)) {
@@ -2342,7 +2343,7 @@ XS(_wrap_Query_id) {
         SWIG_exception(SWIG_UnknownError,"Unknown exception");
       }
     }
-    ST(argvi) = SWIG_From_size_t  SWIG_PERL_CALL_ARGS_1(static_cast< size_t >(result)); argvi++ ;
+    ST(argvi) = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN | 0); argvi++ ;
     
     XSRETURN(argvi);
   fail:
@@ -2843,13 +2844,13 @@ XS(_wrap_Keyset_key_str) {
 XS(_wrap_Keyset_key_id) {
   {
     marisa_swig::Keyset *arg1 = (marisa_swig::Keyset *) 0 ;
-    std::size_t arg2 ;
+    size_t arg2 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
     size_t val2 ;
     int ecode2 = 0 ;
     int argvi = 0;
-    std::size_t result;
+    marisa_key_t result;
     dXSARGS;
     
     if ((items < 2) || (items > 2)) {
@@ -2862,9 +2863,9 @@ XS(_wrap_Keyset_key_id) {
     arg1 = reinterpret_cast< marisa_swig::Keyset * >(argp1);
     ecode2 = SWIG_AsVal_size_t SWIG_PERL_CALL_ARGS_2(ST(1), &val2);
     if (!SWIG_IsOK(ecode2)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Keyset_key_id" "', argument " "2"" of type '" "std::size_t""'");
+      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Keyset_key_id" "', argument " "2"" of type '" "size_t""'");
     } 
-    arg2 = static_cast< std::size_t >(val2);
+    arg2 = static_cast< size_t >(val2);
     {
       try {
         result = ((marisa_swig::Keyset const *)arg1)->key_id(arg2);
@@ -2874,7 +2875,7 @@ XS(_wrap_Keyset_key_id) {
         SWIG_exception(SWIG_UnknownError,"Unknown exception");
       }
     }
-    ST(argvi) = SWIG_From_size_t  SWIG_PERL_CALL_ARGS_1(static_cast< size_t >(result)); argvi++ ;
+    ST(argvi) = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN | 0); argvi++ ;
     
     
     XSRETURN(argvi);
@@ -3213,11 +3214,11 @@ XS(_wrap_Agent_set_query__SWIG_0) {
 XS(_wrap_Agent_set_query__SWIG_1) {
   {
     marisa_swig::Agent *arg1 = (marisa_swig::Agent *) 0 ;
-    std::size_t arg2 ;
+    marisa_key_t arg2 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
-    size_t val2 ;
-    int ecode2 = 0 ;
+    void *argp2 ;
+    int res2 = 0 ;
     int argvi = 0;
     dXSARGS;
     
@@ -3229,11 +3230,17 @@ XS(_wrap_Agent_set_query__SWIG_1) {
       SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Agent_set_query" "', argument " "1"" of type '" "marisa_swig::Agent *""'"); 
     }
     arg1 = reinterpret_cast< marisa_swig::Agent * >(argp1);
-    ecode2 = SWIG_AsVal_size_t SWIG_PERL_CALL_ARGS_2(ST(1), &val2);
-    if (!SWIG_IsOK(ecode2)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Agent_set_query" "', argument " "2"" of type '" "std::size_t""'");
-    } 
-    arg2 = static_cast< std::size_t >(val2);
+    {
+      res2 = SWIG_ConvertPtr(ST(1), &argp2, SWIGTYPE_p_marisa_key_t,  0 );
+      if (!SWIG_IsOK(res2)) {
+        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Agent_set_query" "', argument " "2"" of type '" "marisa_key_t""'"); 
+      }  
+      if (!argp2) {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Agent_set_query" "', argument " "2"" of type '" "marisa_key_t""'");
+      } else {
+        arg2 = *(reinterpret_cast< marisa_key_t * >(argp2));
+      }
+    }
     {
       try {
         (arg1)->set_query(arg2);
@@ -3245,10 +3252,8 @@ XS(_wrap_Agent_set_query__SWIG_1) {
     }
     ST(argvi) = &PL_sv_undef;
     
-    
     XSRETURN(argvi);
   fail:
-    
     
     SWIG_croak_null();
   }
@@ -3276,10 +3281,9 @@ XS(_wrap_Agent_set_query) {
       _rankm += _pi;
       _pi *= SWIG_MAXCASTRANK;
       {
-        {
-          int res = SWIG_AsVal_size_t SWIG_PERL_CALL_ARGS_2(ST(1), NULL);
-          _v = SWIG_CheckState(res);
-        }
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(ST(1), &vptr, SWIGTYPE_p_marisa_key_t, SWIG_POINTER_NO_NULL);
+        _v = SWIG_CheckState(res);
       }
       if (!_v) goto check_1;
       _ranki += _v*_pi;
@@ -3473,7 +3477,7 @@ XS(_wrap_Agent_key_id) {
     void *argp1 = 0 ;
     int res1 = 0 ;
     int argvi = 0;
-    std::size_t result;
+    marisa_key_t result;
     dXSARGS;
     
     if ((items < 1) || (items > 1)) {
@@ -3493,7 +3497,7 @@ XS(_wrap_Agent_key_id) {
         SWIG_exception(SWIG_UnknownError,"Unknown exception");
       }
     }
-    ST(argvi) = SWIG_From_size_t  SWIG_PERL_CALL_ARGS_1(static_cast< size_t >(result)); argvi++ ;
+    ST(argvi) = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN | 0); argvi++ ;
     
     XSRETURN(argvi);
   fail:
@@ -3557,7 +3561,7 @@ XS(_wrap_Agent_query_id) {
     void *argp1 = 0 ;
     int res1 = 0 ;
     int argvi = 0;
-    std::size_t result;
+    marisa_key_t result;
     dXSARGS;
     
     if ((items < 1) || (items > 1)) {
@@ -3577,7 +3581,7 @@ XS(_wrap_Agent_query_id) {
         SWIG_exception(SWIG_UnknownError,"Unknown exception");
       }
     }
-    ST(argvi) = SWIG_From_size_t  SWIG_PERL_CALL_ARGS_1(static_cast< size_t >(result)); argvi++ ;
+    ST(argvi) = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN | 0); argvi++ ;
     
     XSRETURN(argvi);
   fail:
@@ -4333,7 +4337,7 @@ XS(_wrap_Trie_lookup__SWIG_1) {
     size_t size2 = 0 ;
     int alloc2 = 0 ;
     int argvi = 0;
-    std::size_t result;
+    marisa_key_t result;
     dXSARGS;
     
     if ((items < 2) || (items > 2)) {
@@ -4359,7 +4363,7 @@ XS(_wrap_Trie_lookup__SWIG_1) {
         SWIG_exception(SWIG_UnknownError,"Unknown exception");
       }
     }
-    ST(argvi) = SWIG_From_size_t  SWIG_PERL_CALL_ARGS_1(static_cast< size_t >(result)); argvi++ ;
+    ST(argvi) = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN | 0); argvi++ ;
     
     if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
     XSRETURN(argvi);
@@ -4465,13 +4469,13 @@ XS(_wrap_Trie_lookup) {
 XS(_wrap_Trie_reverse_lookup__SWIG_1) {
   {
     marisa_swig::Trie *arg1 = (marisa_swig::Trie *) 0 ;
-    std::size_t arg2 ;
+    marisa_key_t arg2 ;
     char **arg3 = (char **) 0 ;
     std::size_t *arg4 = (std::size_t *) 0 ;
     void *argp1 = 0 ;
     int res1 = 0 ;
-    size_t val2 ;
-    int ecode2 = 0 ;
+    void *argp2 ;
+    int res2 = 0 ;
     char *temp3 = 0 ;
     std::size_t tempn3 ;
     int argvi = 0;
@@ -4486,11 +4490,17 @@ XS(_wrap_Trie_reverse_lookup__SWIG_1) {
       SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Trie_reverse_lookup" "', argument " "1"" of type '" "marisa_swig::Trie const *""'"); 
     }
     arg1 = reinterpret_cast< marisa_swig::Trie * >(argp1);
-    ecode2 = SWIG_AsVal_size_t SWIG_PERL_CALL_ARGS_2(ST(1), &val2);
-    if (!SWIG_IsOK(ecode2)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Trie_reverse_lookup" "', argument " "2"" of type '" "std::size_t""'");
-    } 
-    arg2 = static_cast< std::size_t >(val2);
+    {
+      res2 = SWIG_ConvertPtr(ST(1), &argp2, SWIGTYPE_p_marisa_key_t,  0 );
+      if (!SWIG_IsOK(res2)) {
+        SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Trie_reverse_lookup" "', argument " "2"" of type '" "marisa_key_t""'"); 
+      }  
+      if (!argp2) {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Trie_reverse_lookup" "', argument " "2"" of type '" "marisa_key_t""'");
+      } else {
+        arg2 = *(reinterpret_cast< marisa_key_t * >(argp2));
+      }
+    }
     {
       try {
         ((marisa_swig::Trie const *)arg1)->reverse_lookup(arg2,(char const **)arg3,arg4);
@@ -4509,10 +4519,8 @@ XS(_wrap_Trie_reverse_lookup__SWIG_1) {
     }
     
     
-    
     XSRETURN(argvi);
   fail:
-    
     
     
     SWIG_croak_null();
@@ -4571,10 +4579,9 @@ XS(_wrap_Trie_reverse_lookup) {
       _rankm += _pi;
       _pi *= SWIG_MAXCASTRANK;
       {
-        {
-          int res = SWIG_AsVal_size_t SWIG_PERL_CALL_ARGS_2(ST(1), NULL);
-          _v = SWIG_CheckState(res);
-        }
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(ST(1), &vptr, SWIGTYPE_p_marisa_key_t, SWIG_POINTER_NO_NULL);
+        _v = SWIG_CheckState(res);
       }
       if (!_v) goto check_2;
       _ranki += _v*_pi;
@@ -4965,6 +4972,7 @@ XS(_wrap_Trie_clear) {
 
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa__Key = {"_p_marisa__Key", "marisa::Key *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_marisa_key_t = {"_p_marisa_key_t", "marisa_key_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Agent = {"_p_marisa_swig__Agent", "marisa_swig::Agent *", 0, 0, (void*)"marisa::Agent", 0};
 static swig_type_info _swigt__p_marisa_swig__Key = {"_p_marisa_swig__Key", "marisa_swig::Key *", 0, 0, (void*)"marisa::Key", 0};
 static swig_type_info _swigt__p_marisa_swig__Keyset = {"_p_marisa_swig__Keyset", "marisa_swig::Keyset *", 0, 0, (void*)"marisa::Keyset", 0};
@@ -4976,6 +4984,7 @@ static swig_type_info _swigt__p_std__size_t = {"_p_std__size_t", "std::size_t *"
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_char,
   &_swigt__p_marisa__Key,
+  &_swigt__p_marisa_key_t,
   &_swigt__p_marisa_swig__Agent,
   &_swigt__p_marisa_swig__Key,
   &_swigt__p_marisa_swig__Keyset,
@@ -4987,6 +4996,7 @@ static swig_type_info *swig_type_initial[] = {
 
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa__Key[] = {  {&_swigt__p_marisa__Key, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_marisa_key_t[] = {  {&_swigt__p_marisa_key_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Agent[] = {  {&_swigt__p_marisa_swig__Agent, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Key[] = {  {&_swigt__p_marisa_swig__Key, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Keyset[] = {  {&_swigt__p_marisa_swig__Keyset, 0, 0, 0},{0, 0, 0, 0}};
@@ -4998,6 +5008,7 @@ static swig_cast_info _swigc__p_std__size_t[] = {  {&_swigt__p_std__size_t, 0, 0
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_char,
   _swigc__p_marisa__Key,
+  _swigc__p_marisa_key_t,
   _swigc__p_marisa_swig__Agent,
   _swigc__p_marisa_swig__Key,
   _swigc__p_marisa_swig__Keyset,

--- a/bindings/python3/marisa-swig-python3.cxx
+++ b/bindings/python3/marisa-swig-python3.cxx
@@ -10,7 +10,7 @@ void Key::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = key_.length();
 }
 
-size_t Key::key_id() const {
+marisa_key_t Key::key_id() const {
   return key_.id();
 }
 
@@ -23,7 +23,7 @@ void Query::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = query_.length();
 }
 
-size_t Query::query_id() const {
+marisa_key_t Query::query_id() const {
   return query_.id();
 }
 
@@ -52,7 +52,7 @@ void Keyset::key_str(size_t i,
   *length_out = (*keyset_)[i].length();
 }
 
-size_t Keyset::key_id(size_t i) const {
+marisa_key_t Keyset::key_id(size_t i) const {
   return (*keyset_)[i].id();
 }
 
@@ -108,7 +108,7 @@ void Agent::set_query(const char *ptr, size_t length) {
   agent_->set_query(buf_, length);
 }
 
-void Agent::set_query(size_t id) {
+void Agent::set_query(marisa_key_t id) {
   agent_->set_query(id);
 }
 
@@ -125,7 +125,7 @@ void Agent::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->key().length();
 }
 
-size_t Agent::key_id() const {
+marisa_key_t Agent::key_id() const {
   return agent_->key().id();
 }
 
@@ -134,7 +134,7 @@ void Agent::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->query().length();
 }
 
-size_t Agent::query_id() const {
+marisa_key_t Agent::query_id() const {
   return agent_->query().id();
 }
 
@@ -177,7 +177,7 @@ bool Trie::predictive_search(Agent &agent) const {
   return trie_->predictive_search(*agent.agent_);
 }
 
-size_t Trie::lookup(const char *ptr, size_t length) const {
+marisa_key_t Trie::lookup(const char *ptr, size_t length) const {
   marisa::Agent agent;
   agent.set_query(ptr, length);
   if (!trie_->lookup(agent)) {
@@ -186,7 +186,7 @@ size_t Trie::lookup(const char *ptr, size_t length) const {
   return agent.key().id();
 }
 
-void Trie::reverse_lookup(size_t id,
+void Trie::reverse_lookup(marisa_key_t id,
     const char **ptr_out_to_be_deleted, size_t *length_out) const {
   marisa::Agent agent;
   agent.set_query(id);

--- a/bindings/python3/marisa-swig-python3.h
+++ b/bindings/python3/marisa-swig-python3.h
@@ -57,7 +57,7 @@ enum NodeOrder {
 class Key {
  public:
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
   float weight() const;
 
  private:
@@ -71,7 +71,7 @@ class Key {
 class Query {
  public:
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   const marisa::Query query_;
@@ -95,7 +95,7 @@ class Keyset {
 
   void key_str(std::size_t i,
       const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id(std::size_t i) const;
+  marisa_key_t key_id(std::size_t i) const;
 
   std::size_t num_keys() const;
 
@@ -121,16 +121,16 @@ class Agent {
   ~Agent();
 
   void set_query(const char *ptr, std::size_t length);
-  void set_query(std::size_t id);
+  void set_query(marisa_key_t id);
 
   const Key &key() const;
   const Query &query() const;
 
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
 
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   marisa::Agent *agent_;
@@ -157,8 +157,8 @@ class Trie {
   bool common_prefix_search(Agent &agent) const;
   bool predictive_search(Agent &agent) const;
 
-  std::size_t lookup(const char *ptr, std::size_t length) const;
-  void reverse_lookup(std::size_t id,
+  marisa_key_t lookup(const char *ptr, std::size_t length) const;
+  void reverse_lookup(marisa_key_t id,
       const char **ptr_out_to_be_deleted, std::size_t *length_out) const;
 
   std::size_t num_tries() const;

--- a/bindings/python3/marisa-swig-python3_wrap.cxx
+++ b/bindings/python3/marisa-swig-python3_wrap.cxx
@@ -3153,15 +3153,16 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 
 #define SWIGTYPE_p_char swig_types[0]
 #define SWIGTYPE_p_marisa__Key swig_types[1]
-#define SWIGTYPE_p_marisa_swig__Agent swig_types[2]
-#define SWIGTYPE_p_marisa_swig__Key swig_types[3]
-#define SWIGTYPE_p_marisa_swig__Keyset swig_types[4]
-#define SWIGTYPE_p_marisa_swig__Query swig_types[5]
-#define SWIGTYPE_p_marisa_swig__Trie swig_types[6]
-#define SWIGTYPE_p_p_char swig_types[7]
-#define SWIGTYPE_p_std__size_t swig_types[8]
-static swig_type_info *swig_types[10];
-static swig_module_info swig_module = {swig_types, 9, 0, 0, 0, 0};
+#define SWIGTYPE_p_marisa_key_t swig_types[2]
+#define SWIGTYPE_p_marisa_swig__Agent swig_types[3]
+#define SWIGTYPE_p_marisa_swig__Key swig_types[4]
+#define SWIGTYPE_p_marisa_swig__Keyset swig_types[5]
+#define SWIGTYPE_p_marisa_swig__Query swig_types[6]
+#define SWIGTYPE_p_marisa_swig__Trie swig_types[7]
+#define SWIGTYPE_p_p_char swig_types[8]
+#define SWIGTYPE_p_std__size_t swig_types[9]
+static swig_type_info *swig_types[11];
+static swig_module_info swig_module = {swig_types, 10, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3354,58 +3355,6 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
   } else {
     return SWIG_Py_Void();
   }
-}
-
-
-  #define SWIG_From_long   PyInt_FromLong 
-
-
-SWIGINTERNINLINE PyObject* 
-SWIG_From_unsigned_SS_long  (unsigned long value)
-{
-  return (value > LONG_MAX) ?
-    PyLong_FromUnsignedLong(value) : PyInt_FromLong(static_cast< long >(value));
-}
-
-
-#include <limits.h>
-#if !defined(SWIG_NO_LLONG_MAX)
-# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
-#   define LLONG_MAX __LONG_LONG_MAX__
-#   define LLONG_MIN (-LLONG_MAX - 1LL)
-#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
-# endif
-#endif
-
-
-#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
-#  define SWIG_LONG_LONG_AVAILABLE
-#endif
-
-
-#ifdef SWIG_LONG_LONG_AVAILABLE
-SWIGINTERNINLINE PyObject* 
-SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
-{
-  return (value > LONG_MAX) ?
-    PyLong_FromUnsignedLongLong(value) : PyInt_FromLong(static_cast< long >(value));
-}
-#endif
-
-
-SWIGINTERNINLINE PyObject *
-SWIG_From_size_t  (size_t value)
-{    
-#ifdef SWIG_LONG_LONG_AVAILABLE
-  if (sizeof(size_t) <= sizeof(unsigned long)) {
-#endif
-    return SWIG_From_unsigned_SS_long  (static_cast< unsigned long >(value));
-#ifdef SWIG_LONG_LONG_AVAILABLE
-  } else {
-    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
-    return SWIG_From_unsigned_SS_long_SS_long  (static_cast< unsigned long long >(value));
-  }
-#endif
 }
 
 
@@ -3701,6 +3650,21 @@ SWIG_AsVal_unsigned_SS_long (PyObject *obj, unsigned long *val)
 }
 
 
+#include <limits.h>
+#if !defined(SWIG_NO_LLONG_MAX)
+# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
+#   define LLONG_MAX __LONG_LONG_MAX__
+#   define LLONG_MIN (-LLONG_MAX - 1LL)
+#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
+# endif
+#endif
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
 #ifdef SWIG_LONG_LONG_AVAILABLE
 SWIGINTERN int
 SWIG_AsVal_unsigned_SS_long_SS_long (PyObject *obj, unsigned long long *val)
@@ -3760,6 +3724,43 @@ SWIG_AsVal_size_t (PyObject * obj, size_t *val)
   }
 #endif
   return res;
+}
+
+
+  #define SWIG_From_long   PyInt_FromLong 
+
+
+SWIGINTERNINLINE PyObject* 
+SWIG_From_unsigned_SS_long  (unsigned long value)
+{
+  return (value > LONG_MAX) ?
+    PyLong_FromUnsignedLong(value) : PyInt_FromLong(static_cast< long >(value));
+}
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERNINLINE PyObject* 
+SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
+{
+  return (value > LONG_MAX) ?
+    PyLong_FromUnsignedLongLong(value) : PyInt_FromLong(static_cast< long >(value));
+}
+#endif
+
+
+SWIGINTERNINLINE PyObject *
+SWIG_From_size_t  (size_t value)
+{    
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    return SWIG_From_unsigned_SS_long  (static_cast< unsigned long >(value));
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else {
+    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
+    return SWIG_From_unsigned_SS_long_SS_long  (static_cast< unsigned long long >(value));
+  }
+#endif
 }
 
 
@@ -3882,7 +3883,7 @@ SWIGINTERN PyObject *_wrap_Key_key_id(PyObject *self, PyObject *args) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::size_t result;
+  marisa_key_t result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -3901,7 +3902,7 @@ SWIGINTERN PyObject *_wrap_Key_key_id(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  resultobj = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4024,7 +4025,7 @@ SWIGINTERN PyObject *_wrap_Query_query_id(PyObject *self, PyObject *args) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::size_t result;
+  marisa_key_t result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -4043,7 +4044,7 @@ SWIGINTERN PyObject *_wrap_Query_query_id(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  resultobj = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4443,7 +4444,7 @@ SWIGINTERN PyObject *_wrap_Keyset_key_id(PyObject *self, PyObject *args) {
   size_t val2 ;
   int ecode2 = 0 ;
   PyObject *swig_obj[2] ;
-  std::size_t result;
+  marisa_key_t result;
   
   (void)self;
   if (!SWIG_Python_UnpackTuple(args, "Keyset_key_id", 2, 2, swig_obj)) SWIG_fail;
@@ -4466,7 +4467,7 @@ SWIGINTERN PyObject *_wrap_Keyset_key_id(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  resultobj = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4773,11 +4774,11 @@ fail:
 SWIGINTERN PyObject *_wrap_Agent_set_query__SWIG_1(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   marisa_swig::Agent *arg1 = (marisa_swig::Agent *) 0 ;
-  std::size_t arg2 ;
+  marisa_key_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  size_t val2 ;
-  int ecode2 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
   
   (void)self;
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -4786,11 +4787,19 @@ SWIGINTERN PyObject *_wrap_Agent_set_query__SWIG_1(PyObject *self, Py_ssize_t no
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Agent_set_query" "', argument " "1"" of type '" "marisa_swig::Agent *""'"); 
   }
   arg1 = reinterpret_cast< marisa_swig::Agent * >(argp1);
-  ecode2 = SWIG_AsVal_size_t(swig_obj[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Agent_set_query" "', argument " "2"" of type '" "std::size_t""'");
-  } 
-  arg2 = static_cast< std::size_t >(val2);
+  {
+    res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_marisa_key_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Agent_set_query" "', argument " "2"" of type '" "marisa_key_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Agent_set_query" "', argument " "2"" of type '" "marisa_key_t""'");
+    } else {
+      marisa_key_t * temp = reinterpret_cast< marisa_key_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
   {
     try {
       (arg1)->set_query(arg2);
@@ -4821,10 +4830,8 @@ SWIGINTERN PyObject *_wrap_Agent_set_query(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_marisa_swig__Agent, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      {
-        int res = SWIG_AsVal_size_t(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_marisa_key_t, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
       if (_v) {
         return _wrap_Agent_set_query__SWIG_1(self, argc, argv);
       }
@@ -4857,7 +4864,7 @@ fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'Agent_set_query'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    marisa_swig::Agent::set_query(char const *,std::size_t)\n"
-    "    marisa_swig::Agent::set_query(std::size_t)\n");
+    "    marisa_swig::Agent::set_query(marisa_key_t)\n");
   return 0;
 }
 
@@ -4972,7 +4979,7 @@ SWIGINTERN PyObject *_wrap_Agent_key_id(PyObject *self, PyObject *args) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::size_t result;
+  marisa_key_t result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -4991,7 +4998,7 @@ SWIGINTERN PyObject *_wrap_Agent_key_id(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  resultobj = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -5044,7 +5051,7 @@ SWIGINTERN PyObject *_wrap_Agent_query_id(PyObject *self, PyObject *args) {
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  std::size_t result;
+  marisa_key_t result;
   
   (void)self;
   if (!args) SWIG_fail;
@@ -5063,7 +5070,7 @@ SWIGINTERN PyObject *_wrap_Agent_query_id(PyObject *self, PyObject *args) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  resultobj = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -5670,7 +5677,7 @@ SWIGINTERN PyObject *_wrap_Trie_lookup__SWIG_1(PyObject *self, Py_ssize_t nobjs,
   char *buf2 = 0 ;
   size_t size2 = 0 ;
   int alloc2 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   
   (void)self;
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -5694,7 +5701,7 @@ SWIGINTERN PyObject *_wrap_Trie_lookup__SWIG_1(PyObject *self, Py_ssize_t nobjs,
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  resultobj = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
   return resultobj;
 fail:
@@ -5760,13 +5767,13 @@ fail:
 SWIGINTERN PyObject *_wrap_Trie_reverse_lookup__SWIG_1(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   marisa_swig::Trie *arg1 = (marisa_swig::Trie *) 0 ;
-  std::size_t arg2 ;
+  marisa_key_t arg2 ;
   char **arg3 = (char **) 0 ;
   std::size_t *arg4 = (std::size_t *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  size_t val2 ;
-  int ecode2 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
   char *temp3 = 0 ;
   std::size_t tempn3 ;
   
@@ -5778,11 +5785,19 @@ SWIGINTERN PyObject *_wrap_Trie_reverse_lookup__SWIG_1(PyObject *self, Py_ssize_
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Trie_reverse_lookup" "', argument " "1"" of type '" "marisa_swig::Trie const *""'"); 
   }
   arg1 = reinterpret_cast< marisa_swig::Trie * >(argp1);
-  ecode2 = SWIG_AsVal_size_t(swig_obj[1], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Trie_reverse_lookup" "', argument " "2"" of type '" "std::size_t""'");
-  } 
-  arg2 = static_cast< std::size_t >(val2);
+  {
+    res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_marisa_key_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Trie_reverse_lookup" "', argument " "2"" of type '" "marisa_key_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Trie_reverse_lookup" "', argument " "2"" of type '" "marisa_key_t""'");
+    } else {
+      marisa_key_t * temp = reinterpret_cast< marisa_key_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
   {
     try {
       ((marisa_swig::Trie const *)arg1)->reverse_lookup(arg2,(char const **)arg3,arg4);
@@ -5831,10 +5846,8 @@ SWIGINTERN PyObject *_wrap_Trie_reverse_lookup(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_marisa_swig__Trie, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      {
-        int res = SWIG_AsVal_size_t(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_marisa_key_t, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
       if (_v) {
         return _wrap_Trie_reverse_lookup__SWIG_1(self, argc, argv);
       }
@@ -5845,7 +5858,7 @@ fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'Trie_reverse_lookup'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    marisa_swig::Trie::reverse_lookup(marisa_swig::Agent &) const\n"
-    "    marisa_swig::Trie::reverse_lookup(std::size_t,char const **,std::size_t *) const\n");
+    "    marisa_swig::Trie::reverse_lookup(marisa_key_t,char const **,std::size_t *) const\n");
   return 0;
 }
 
@@ -6245,6 +6258,7 @@ static PyMethodDef SwigMethods[] = {
 
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa__Key = {"_p_marisa__Key", "marisa::Key *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_marisa_key_t = {"_p_marisa_key_t", "marisa_key_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Agent = {"_p_marisa_swig__Agent", "marisa_swig::Agent *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Key = {"_p_marisa_swig__Key", "marisa_swig::Key *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Keyset = {"_p_marisa_swig__Keyset", "marisa_swig::Keyset *", 0, 0, (void*)0, 0};
@@ -6256,6 +6270,7 @@ static swig_type_info _swigt__p_std__size_t = {"_p_std__size_t", "std::size_t *"
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_char,
   &_swigt__p_marisa__Key,
+  &_swigt__p_marisa_key_t,
   &_swigt__p_marisa_swig__Agent,
   &_swigt__p_marisa_swig__Key,
   &_swigt__p_marisa_swig__Keyset,
@@ -6267,6 +6282,7 @@ static swig_type_info *swig_type_initial[] = {
 
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa__Key[] = {  {&_swigt__p_marisa__Key, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_marisa_key_t[] = {  {&_swigt__p_marisa_key_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Agent[] = {  {&_swigt__p_marisa_swig__Agent, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Key[] = {  {&_swigt__p_marisa_swig__Key, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Keyset[] = {  {&_swigt__p_marisa_swig__Keyset, 0, 0, 0},{0, 0, 0, 0}};
@@ -6278,6 +6294,7 @@ static swig_cast_info _swigc__p_std__size_t[] = {  {&_swigt__p_std__size_t, 0, 0
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_char,
   _swigc__p_marisa__Key,
+  _swigc__p_marisa_key_t,
   _swigc__p_marisa_swig__Agent,
   _swigc__p_marisa_swig__Key,
   _swigc__p_marisa_swig__Keyset,

--- a/bindings/ruby/marisa-swig.cxx
+++ b/bindings/ruby/marisa-swig.cxx
@@ -10,7 +10,7 @@ void Key::str(const char **ptr_out, size_t *length_out) const {
   *length_out = key_.length();
 }
 
-size_t Key::id() const {
+marisa_key_t Key::id() const {
   return key_.id();
 }
 
@@ -23,7 +23,7 @@ void Query::str(const char **ptr_out, size_t *length_out) const {
   *length_out = query_.length();
 }
 
-size_t Query::id() const {
+marisa_key_t Query::id() const {
   return query_.id();
 }
 
@@ -52,7 +52,7 @@ void Keyset::key_str(size_t i,
   *length_out = (*keyset_)[i].length();
 }
 
-size_t Keyset::key_id(size_t i) const {
+marisa_key_t Keyset::key_id(size_t i) const {
   return (*keyset_)[i].id();
 }
 
@@ -108,7 +108,7 @@ void Agent::set_query(const char *ptr, size_t length) {
   agent_->set_query(buf_, length);
 }
 
-void Agent::set_query(size_t id) {
+void Agent::set_query(marisa_key_t id) {
   agent_->set_query(id);
 }
 
@@ -125,7 +125,7 @@ void Agent::key_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->key().length();
 }
 
-size_t Agent::key_id() const {
+marisa_key_t Agent::key_id() const {
   return agent_->key().id();
 }
 
@@ -134,7 +134,7 @@ void Agent::query_str(const char **ptr_out, size_t *length_out) const {
   *length_out = agent_->query().length();
 }
 
-size_t Agent::query_id() const {
+marisa_key_t Agent::query_id() const {
   return agent_->query().id();
 }
 
@@ -177,7 +177,7 @@ bool Trie::predictive_search(Agent &agent) const {
   return trie_->predictive_search(*agent.agent_);
 }
 
-size_t Trie::lookup(const char *ptr, size_t length) const {
+marisa_key_t Trie::lookup(const char *ptr, size_t length) const {
   marisa::Agent agent;
   agent.set_query(ptr, length);
   if (!trie_->lookup(agent)) {
@@ -186,7 +186,7 @@ size_t Trie::lookup(const char *ptr, size_t length) const {
   return agent.key().id();
 }
 
-void Trie::reverse_lookup(size_t id,
+void Trie::reverse_lookup(marisa_key_t id,
     const char **ptr_out_to_be_deleted, size_t *length_out) const {
   marisa::Agent agent;
   agent.set_query(id);

--- a/bindings/ruby/marisa-swig.h
+++ b/bindings/ruby/marisa-swig.h
@@ -57,7 +57,7 @@ enum NodeOrder {
 class Key {
  public:
   void str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t id() const;
+  marisa_key_t id() const;
   float weight() const;
 
  private:
@@ -71,7 +71,7 @@ class Key {
 class Query {
  public:
   void str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t id() const;
+  marisa_key_t id() const;
 
  private:
   const marisa::Query query_;
@@ -95,7 +95,7 @@ class Keyset {
 
   void key_str(std::size_t i,
       const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id(std::size_t i) const;
+  marisa_key_t key_id(size_t i) const;
 
   std::size_t num_keys() const;
 
@@ -121,16 +121,16 @@ class Agent {
   ~Agent();
 
   void set_query(const char *ptr, std::size_t length);
-  void set_query(std::size_t id);
+  void set_query(marisa_key_t id);
 
   const Key &key() const;
   const Query &query() const;
 
   void key_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t key_id() const;
+  marisa_key_t key_id() const;
 
   void query_str(const char **ptr_out, std::size_t *length_out) const;
-  std::size_t query_id() const;
+  marisa_key_t query_id() const;
 
  private:
   marisa::Agent *agent_;
@@ -157,8 +157,8 @@ class Trie {
   bool common_prefix_search(Agent &agent) const;
   bool predictive_search(Agent &agent) const;
 
-  std::size_t lookup(const char *ptr, std::size_t length) const;
-  void reverse_lookup(std::size_t id,
+  marisa_key_t lookup(const char *ptr, std::size_t length) const;
+  void reverse_lookup(marisa_key_t id,
       const char **ptr_out_to_be_deleted, std::size_t *length_out) const;
 
   std::size_t num_tries() const;

--- a/bindings/ruby/marisa-swig_wrap.cxx
+++ b/bindings/ruby/marisa-swig_wrap.cxx
@@ -1889,15 +1889,16 @@ int SWIG_Ruby_arity( VALUE proc, int minimal )
 
 #define SWIGTYPE_p_char swig_types[0]
 #define SWIGTYPE_p_marisa__Key swig_types[1]
-#define SWIGTYPE_p_marisa_swig__Agent swig_types[2]
-#define SWIGTYPE_p_marisa_swig__Key swig_types[3]
-#define SWIGTYPE_p_marisa_swig__Keyset swig_types[4]
-#define SWIGTYPE_p_marisa_swig__Query swig_types[5]
-#define SWIGTYPE_p_marisa_swig__Trie swig_types[6]
-#define SWIGTYPE_p_p_char swig_types[7]
-#define SWIGTYPE_p_std__size_t swig_types[8]
-static swig_type_info *swig_types[10];
-static swig_module_info swig_module = {swig_types, 9, 0, 0, 0, 0};
+#define SWIGTYPE_p_marisa_key_t swig_types[2]
+#define SWIGTYPE_p_marisa_swig__Agent swig_types[3]
+#define SWIGTYPE_p_marisa_swig__Key swig_types[4]
+#define SWIGTYPE_p_marisa_swig__Keyset swig_types[5]
+#define SWIGTYPE_p_marisa_swig__Query swig_types[6]
+#define SWIGTYPE_p_marisa_swig__Trie swig_types[7]
+#define SWIGTYPE_p_p_char swig_types[8]
+#define SWIGTYPE_p_std__size_t swig_types[9]
+static swig_type_info *swig_types[11];
+static swig_module_info swig_module = {swig_types, 10, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -2017,43 +2018,6 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
   } else {
     return Qnil;
   }
-}
-
-
-SWIGINTERNINLINE VALUE
-SWIG_From_unsigned_SS_long  (unsigned long value)
-{
-  return ULONG2NUM(value); 
-}
-
-
-#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
-#  define SWIG_LONG_LONG_AVAILABLE
-#endif
-
-
-#ifdef SWIG_LONG_LONG_AVAILABLE
-SWIGINTERNINLINE VALUE 
-SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
-{
-  return ULL2NUM(value);
-}
-#endif
-
-
-SWIGINTERNINLINE VALUE
-SWIG_From_size_t  (size_t value)
-{    
-#ifdef SWIG_LONG_LONG_AVAILABLE
-  if (sizeof(size_t) <= sizeof(unsigned long)) {
-#endif
-    return SWIG_From_unsigned_SS_long  (static_cast< unsigned long >(value));
-#ifdef SWIG_LONG_LONG_AVAILABLE
-  } else {
-    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
-    return SWIG_From_unsigned_SS_long_SS_long  (static_cast< unsigned long long >(value));
-  }
-#endif
 }
 
 
@@ -2235,6 +2199,11 @@ SWIG_AsVal_unsigned_SS_long (VALUE obj, unsigned long *val)
 }
 
 
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
 #ifdef SWIG_LONG_LONG_AVAILABLE
 /*@SWIG:/usr/share/swig4.0/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULL(VALUE arg)
@@ -2287,6 +2256,38 @@ SWIG_AsVal_size_t (VALUE obj, size_t *val)
   }
 #endif
   return res;
+}
+
+
+SWIGINTERNINLINE VALUE
+SWIG_From_unsigned_SS_long  (unsigned long value)
+{
+  return ULONG2NUM(value); 
+}
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERNINLINE VALUE 
+SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
+{
+  return ULL2NUM(value);
+}
+#endif
+
+
+SWIGINTERNINLINE VALUE
+SWIG_From_size_t  (size_t value)
+{    
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    return SWIG_From_unsigned_SS_long  (static_cast< unsigned long >(value));
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else {
+    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
+    return SWIG_From_unsigned_SS_long_SS_long  (static_cast< unsigned long long >(value));
+  }
+#endif
 }
 
 
@@ -2388,7 +2389,7 @@ _wrap_Key_id(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Key *arg1 = (marisa_swig::Key *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -2408,7 +2409,7 @@ _wrap_Key_id(int argc, VALUE *argv, VALUE self) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  vresult = SWIG_From_size_t(static_cast< size_t >(result));
+  vresult = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -2499,7 +2500,7 @@ _wrap_Query_id(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Query *arg1 = (marisa_swig::Query *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -2519,7 +2520,7 @@ _wrap_Query_id(int argc, VALUE *argv, VALUE self) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  vresult = SWIG_From_size_t(static_cast< size_t >(result));
+  vresult = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -2879,12 +2880,12 @@ fail:
 SWIGINTERN VALUE
 _wrap_Keyset_key_id(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Keyset *arg1 = (marisa_swig::Keyset *) 0 ;
-  std::size_t arg2 ;
+  size_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   size_t val2 ;
   int ecode2 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 1) || (argc > 1)) {
@@ -2897,9 +2898,9 @@ _wrap_Keyset_key_id(int argc, VALUE *argv, VALUE self) {
   arg1 = reinterpret_cast< marisa_swig::Keyset * >(argp1);
   ecode2 = SWIG_AsVal_size_t(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "std::size_t","key_id", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "size_t","key_id", 2, argv[0] ));
   } 
-  arg2 = static_cast< std::size_t >(val2);
+  arg2 = static_cast< size_t >(val2);
   {
     try {
       result = ((marisa_swig::Keyset const *)arg1)->key_id(arg2);
@@ -2909,7 +2910,7 @@ _wrap_Keyset_key_id(int argc, VALUE *argv, VALUE self) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  vresult = SWIG_From_size_t(static_cast< size_t >(result));
+  vresult = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -3210,11 +3211,11 @@ fail:
 SWIGINTERN VALUE
 _wrap_Agent_set_query__SWIG_1(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Agent *arg1 = (marisa_swig::Agent *) 0 ;
-  std::size_t arg2 ;
+  marisa_key_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  size_t val2 ;
-  int ecode2 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
   
   if ((argc < 1) || (argc > 1)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
@@ -3224,11 +3225,17 @@ _wrap_Agent_set_query__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "marisa_swig::Agent *","set_query", 1, self )); 
   }
   arg1 = reinterpret_cast< marisa_swig::Agent * >(argp1);
-  ecode2 = SWIG_AsVal_size_t(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "std::size_t","set_query", 2, argv[0] ));
-  } 
-  arg2 = static_cast< std::size_t >(val2);
+  {
+    res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_marisa_key_t,  0 );
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "marisa_key_t","set_query", 2, argv[0] )); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "marisa_key_t","set_query", 2, argv[0]));
+    } else {
+      arg2 = *(reinterpret_cast< marisa_key_t * >(argp2));
+    }
+  }
   {
     try {
       (arg1)->set_query(arg2);
@@ -3261,10 +3268,9 @@ SWIGINTERN VALUE _wrap_Agent_set_query(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_marisa_swig__Agent, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      {
-        int res = SWIG_AsVal_size_t(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_marisa_key_t, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
       if (_v) {
         return _wrap_Agent_set_query__SWIG_1(nargs, args, self);
       }
@@ -3296,7 +3302,7 @@ SWIGINTERN VALUE _wrap_Agent_set_query(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Agent.set_query", 
     "    void Agent.set_query(char const *ptr, std::size_t length)\n"
-    "    void Agent.set_query(std::size_t id)\n");
+    "    void Agent.set_query(marisa_key_t id)\n");
   
   return Qnil;
 }
@@ -3410,7 +3416,7 @@ _wrap_Agent_key_id(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Agent *arg1 = (marisa_swig::Agent *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -3430,7 +3436,7 @@ _wrap_Agent_key_id(int argc, VALUE *argv, VALUE self) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  vresult = SWIG_From_size_t(static_cast< size_t >(result));
+  vresult = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -3481,7 +3487,7 @@ _wrap_Agent_query_id(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Agent *arg1 = (marisa_swig::Agent *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -3501,7 +3507,7 @@ _wrap_Agent_query_id(int argc, VALUE *argv, VALUE self) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  vresult = SWIG_From_size_t(static_cast< size_t >(result));
+  vresult = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   return vresult;
 fail:
   return Qnil;
@@ -4098,7 +4104,7 @@ _wrap_Trie_lookup__SWIG_1(int argc, VALUE *argv, VALUE self) {
   char *buf2 = 0 ;
   size_t size2 = 0 ;
   int alloc2 = 0 ;
-  std::size_t result;
+  marisa_key_t result;
   VALUE vresult = Qnil;
   
   if ((argc < 1) || (argc > 1)) {
@@ -4124,7 +4130,7 @@ _wrap_Trie_lookup__SWIG_1(int argc, VALUE *argv, VALUE self) {
       SWIG_exception(SWIG_UnknownError,"Unknown exception");
     }
   }
-  vresult = SWIG_From_size_t(static_cast< size_t >(result));
+  vresult = SWIG_NewPointerObj((new marisa_key_t(result)), SWIGTYPE_p_marisa_key_t, SWIG_POINTER_OWN |  0 );
   if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
   return vresult;
 fail:
@@ -4184,7 +4190,7 @@ SWIGINTERN VALUE _wrap_Trie_lookup(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Trie.lookup", 
     "    bool Trie.lookup(marisa_swig::Agent &agent)\n"
-    "    std::size_t Trie.lookup(char const *ptr, std::size_t length)\n");
+    "    marisa_key_t Trie.lookup(char const *ptr, std::size_t length)\n");
   
   return Qnil;
 }
@@ -4193,13 +4199,13 @@ fail:
 SWIGINTERN VALUE
 _wrap_Trie_reverse_lookup__SWIG_1(int argc, VALUE *argv, VALUE self) {
   marisa_swig::Trie *arg1 = (marisa_swig::Trie *) 0 ;
-  std::size_t arg2 ;
+  marisa_key_t arg2 ;
   char **arg3 = (char **) 0 ;
   std::size_t *arg4 = (std::size_t *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  size_t val2 ;
-  int ecode2 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
   char *temp3 = 0 ;
   std::size_t tempn3 ;
   VALUE vresult = Qnil;
@@ -4213,11 +4219,17 @@ _wrap_Trie_reverse_lookup__SWIG_1(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "marisa_swig::Trie const *","reverse_lookup", 1, self )); 
   }
   arg1 = reinterpret_cast< marisa_swig::Trie * >(argp1);
-  ecode2 = SWIG_AsVal_size_t(argv[0], &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "std::size_t","reverse_lookup", 2, argv[0] ));
-  } 
-  arg2 = static_cast< std::size_t >(val2);
+  {
+    res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_marisa_key_t,  0 );
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "marisa_key_t","reverse_lookup", 2, argv[0] )); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "marisa_key_t","reverse_lookup", 2, argv[0]));
+    } else {
+      arg2 = *(reinterpret_cast< marisa_key_t * >(argp2));
+    }
+  }
   {
     try {
       ((marisa_swig::Trie const *)arg1)->reverse_lookup(arg2,(char const **)arg3,arg4);
@@ -4268,10 +4280,9 @@ SWIGINTERN VALUE _wrap_Trie_reverse_lookup(int nargs, VALUE *args, VALUE self) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_marisa_swig__Trie, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      {
-        int res = SWIG_AsVal_size_t(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_marisa_key_t, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
       if (_v) {
         return _wrap_Trie_reverse_lookup__SWIG_1(nargs, args, self);
       }
@@ -4281,7 +4292,7 @@ SWIGINTERN VALUE _wrap_Trie_reverse_lookup(int nargs, VALUE *args, VALUE self) {
 fail:
   Ruby_Format_OverloadedError( argc, 3, "Trie.reverse_lookup", 
     "    void Trie.reverse_lookup(marisa_swig::Agent &agent)\n"
-    "    void Trie.reverse_lookup(std::size_t id, char const **ptr_out_to_be_deleted, std::size_t *length_out)\n");
+    "    void Trie.reverse_lookup(marisa_key_t id, char const **ptr_out_to_be_deleted, std::size_t *length_out)\n");
   
   return Qnil;
 }
@@ -4625,6 +4636,7 @@ fail:
 
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa__Key = {"_p_marisa__Key", "marisa::Key *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_marisa_key_t = {"_p_marisa_key_t", "marisa_key_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Agent = {"_p_marisa_swig__Agent", "marisa_swig::Agent *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Key = {"_p_marisa_swig__Key", "marisa_swig::Key *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_marisa_swig__Keyset = {"_p_marisa_swig__Keyset", "marisa_swig::Keyset *", 0, 0, (void*)0, 0};
@@ -4636,6 +4648,7 @@ static swig_type_info _swigt__p_std__size_t = {"_p_std__size_t", "std::size_t *"
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_char,
   &_swigt__p_marisa__Key,
+  &_swigt__p_marisa_key_t,
   &_swigt__p_marisa_swig__Agent,
   &_swigt__p_marisa_swig__Key,
   &_swigt__p_marisa_swig__Keyset,
@@ -4647,6 +4660,7 @@ static swig_type_info *swig_type_initial[] = {
 
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa__Key[] = {  {&_swigt__p_marisa__Key, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_marisa_key_t[] = {  {&_swigt__p_marisa_key_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Agent[] = {  {&_swigt__p_marisa_swig__Agent, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Key[] = {  {&_swigt__p_marisa_swig__Key, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_marisa_swig__Keyset[] = {  {&_swigt__p_marisa_swig__Keyset, 0, 0, 0},{0, 0, 0, 0}};
@@ -4658,6 +4672,7 @@ static swig_cast_info _swigc__p_std__size_t[] = {  {&_swigt__p_std__size_t, 0, 0
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_char,
   _swigc__p_marisa__Key,
+  _swigc__p_marisa_key_t,
   _swigc__p_marisa_swig__Agent,
   _swigc__p_marisa_swig__Key,
   _swigc__p_marisa_swig__Keyset,

--- a/include/marisa/agent.h
+++ b/include/marisa/agent.h
@@ -37,7 +37,7 @@ class Agent {
   }
   void set_query(const char *str);
   void set_query(const char *ptr, std::size_t length);
-  void set_query(std::size_t key_id);
+  void set_query(marisa_key_t key_id);
 
   const grimoire::trie::State &state() const {
     return *state_;
@@ -58,7 +58,7 @@ class Agent {
     assert(length <= UINT32_MAX);
     key_.set_str(ptr, length);
   }
-  void set_key(std::size_t id) {
+  void set_key(marisa_key_t id) {
     assert(id <= UINT32_MAX);
     key_.set_id(id);
   }

--- a/include/marisa/base.h
+++ b/include/marisa/base.h
@@ -28,6 +28,9 @@ using marisa_uint64 [[deprecated]] = std::uint64_t;
 [[deprecated]] constexpr auto MARISA_UINT64_MAX = UINT64_MAX;
 [[deprecated]] constexpr auto MARISA_SIZE_MAX = SIZE_MAX;
 
+// Key IDs are always 32-bit unsigned integers.
+using marisa_key_t = size_t;
+
 #define MARISA_INVALID_LINK_ID UINT32_MAX
 #define MARISA_INVALID_KEY_ID  UINT32_MAX
 #define MARISA_INVALID_EXTRA   (UINT32_MAX >> 8)

--- a/include/marisa/key.h
+++ b/include/marisa/key.h
@@ -38,7 +38,7 @@ class Key {
     ptr_ = ptr;
     length_ = static_cast<uint32_t>(length);
   }
-  void set_id(std::size_t id) {
+  void set_id(marisa_key_t id) {
     assert(id <= UINT32_MAX);
     union_.id = static_cast<uint32_t>(id);
   }
@@ -55,7 +55,7 @@ class Key {
   std::size_t length() const {
     return length_;
   }
-  std::size_t id() const {
+  marisa_key_t id() const {
     return union_.id;
   }
   float weight() const {
@@ -75,7 +75,7 @@ class Key {
   const char *ptr_ = nullptr;
   uint32_t length_ = 0;
   union Union {
-    uint32_t id = 0;
+    marisa_key_t id = 0;
     float weight;
   } union_;
 };

--- a/include/marisa/query.h
+++ b/include/marisa/query.h
@@ -37,7 +37,7 @@ class Query {
     ptr_ = ptr;
     length_ = length;
   }
-  void set_id(std::size_t id) {
+  void set_id(marisa_key_t id) {
     id_ = id;
   }
 
@@ -50,7 +50,7 @@ class Query {
   std::size_t length() const {
     return length_;
   }
-  std::size_t id() const {
+  marisa_key_t id() const {
     return id_;
   }
 
@@ -66,7 +66,7 @@ class Query {
  private:
   const char *ptr_ = nullptr;
   std::size_t length_ = 0;
-  std::size_t id_ = 0;
+  marisa_key_t id_ = 0;
 };
 
 }  // namespace marisa

--- a/lib/marisa/agent.cc
+++ b/lib/marisa/agent.cc
@@ -73,7 +73,7 @@ void Agent::set_query(const char *ptr, std::size_t length) {
   query_.set_str(ptr, length);
 }
 
-void Agent::set_query(std::size_t key_id) {
+void Agent::set_query(marisa_key_t key_id) {
   if (state_ != nullptr) {
     state_->reset();
   }

--- a/tools/marisa-reverse-lookup.cc
+++ b/tools/marisa-reverse-lookup.cc
@@ -52,7 +52,7 @@ int reverse_lookup(const char *const *args, std::size_t num_args) {
   }
 
   marisa::Agent agent;
-  std::size_t key_id;
+  marisa_key_t key_id;
   while (std::cin >> key_id) {
     try {
       agent.set_query(key_id);


### PR DESCRIPTION
This is a non-breaking change in preparation for changing them to be explicitly a `uint32_t` later.