### PR TITLE
Fix MSVC x86 and MinGW builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # for clang-tidy
 
 # Target Windows 8 for PrefetchVirtualMemory
-if (MINGW)
+if (WIN32)
     add_compile_definitions(_WIN32_WINNT=_WIN32_WINNT_WIN8)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # for clang-tidy
 
 # Target Windows 8 for PrefetchVirtualMemory
-if (WIN32)
+if (MINGW)
     add_compile_definitions(_WIN32_WINNT=_WIN32_WINNT_WIN8)
 endif()
 

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -3,8 +3,7 @@
  #ifndef _WIN32_WINNT
   #define _WIN32_WINNT 0x0602
  #elif _WIN32_WINNT < 0x0602
-  #undef _WIN32_WINNT
-  #define _WIN32_WINNT 0x0602
+  #error marisa-trie requires _WIN32_WINNT >= 0x0602 (Windows 8)
  #endif
  #include <sys/stat.h>
  #include <sys/types.h>

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -1,4 +1,11 @@
 #if (defined _WIN32) || (defined _WIN64)
+ // Require Windows 8+ for PrefetchVirtualMemory / WIN32_MEMORY_RANGE_ENTRY
+ #ifndef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0602
+ #elif _WIN32_WINNT < 0x0602
+  #undef _WIN32_WINNT
+  #define _WIN32_WINNT 0x0602
+ #endif
  #include <sys/stat.h>
  #include <sys/types.h>
  #include <windows.h>

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -130,15 +130,15 @@ void Mapper::open_(const char *filename, int flags) {
   MARISA_THROW_SYSTEM_ERROR_IF(origin_ == nullptr, ::GetLastError(),
                                std::system_category(), "MapViewOfFile");
 
-  if (flags & MARISA_MAP_POPULATE) {
+  // PrefetchVirtualMemory requires Windows 8+ (_WIN32_WINNT >= 0x0602).
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
-    // PrefetchVirtualMemory requires Windows 8+.
+  if (flags & MARISA_MAP_POPULATE) {
     WIN32_MEMORY_RANGE_ENTRY range_entry;
     range_entry.VirtualAddress = origin_;
     range_entry.NumberOfBytes = size_;
     ::PrefetchVirtualMemory(GetCurrentProcess(), 1, &range_entry, 0);
-#endif
   }
+#endif
 
   ptr_ = static_cast<const char *>(origin_);
   avail_ = size_;

--- a/lib/marisa/grimoire/io/mapper.cc
+++ b/lib/marisa/grimoire/io/mapper.cc
@@ -1,10 +1,4 @@
 #if (defined _WIN32) || (defined _WIN64)
- // Require Windows 8+ for PrefetchVirtualMemory / WIN32_MEMORY_RANGE_ENTRY
- #ifndef _WIN32_WINNT
-  #define _WIN32_WINNT 0x0602
- #elif _WIN32_WINNT < 0x0602
-  #error marisa-trie requires _WIN32_WINNT >= 0x0602 (Windows 8)
- #endif
  #include <sys/stat.h>
  #include <sys/types.h>
  #include <windows.h>
@@ -137,10 +131,13 @@ void Mapper::open_(const char *filename, int flags) {
                                std::system_category(), "MapViewOfFile");
 
   if (flags & MARISA_MAP_POPULATE) {
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
+    // PrefetchVirtualMemory requires Windows 8+.
     WIN32_MEMORY_RANGE_ENTRY range_entry;
     range_entry.VirtualAddress = origin_;
     range_entry.NumberOfBytes = size_;
     ::PrefetchVirtualMemory(GetCurrentProcess(), 1, &range_entry, 0);
+#endif
   }
 
   ptr_ = static_cast<const char *>(origin_);

--- a/lib/marisa/grimoire/vector/bit-vector.cc
+++ b/lib/marisa/grimoire/vector/bit-vector.cc
@@ -22,7 +22,16 @@ inline std::size_t countr_zero(uint64_t x) {
 inline std::size_t countr_zero(uint64_t x) {
  #ifdef _MSC_VER
   unsigned long pos;
+  #if defined(_M_X64) || defined(_M_ARM64)
   ::_BitScanForward64(&pos, x);
+  #else
+  // _BitScanForward64 is not available on 32-bit MSVC targets.
+  if (::_BitScanForward(&pos, static_cast<unsigned long>(x))) {
+    return pos;
+  }
+  ::_BitScanForward(&pos, static_cast<unsigned long>(x >> 32));
+  pos += 32;
+  #endif
   return pos;
  #else   // _MSC_VER
   return __builtin_ctzll(x);


### PR DESCRIPTION
## Summary
- Use `_BitScanForward` fallback in `bit-vector.cc` for 32-bit MSVC targets where `_BitScanForward64` is unavailable
- Ad #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602 to guard `PrefetchVirtualMemory` and `WIN32_MEMORY_RANGE_ENTRY`
- CMakeLists.txt: Changed if (MINGW) to if (WIN32) so _WIN32_WINNT=_WIN32_WINNT_WIN8 is set for all Windows targets (per luadebug’s suggestion).

Ported from https://github.com/BYVoid/OpenCC/pull/1078.

## Test plan
- [x] Verify CI passes on existing platforms
- [x] Build with MSVC x86 (Win32) target
- [x] Build with MinGW toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)