### PR TITLE
Add Bazel build support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,5 @@
+build --enable_platform_specific_config
+
+build:linux --cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17
+build:windows --cxxopt=/std:c++17

--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,4 @@ build --enable_platform_specific_config
 build:linux --cxxopt=-std=c++17
 build:macos --cxxopt=-std=c++17
 build:windows --cxxopt=/std:c++17
+build:windows --copt=-D_WIN32_WINNT=_WIN32_WINNT_WIN8

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,40 @@
+name: Bazel CI
+
+on:
+  push:
+    branches: [master, develop]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bazel:
+    name: Bazel - ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build
+        run: bazel build //:marisa-trie
+
+      - name: Test
+        run: bazel test //...

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ tools/marisa-predictive-search
 tools/marisa-reverse-lookup
 /build/
 /build-*/
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+package(default_visibility = ["//visibility:public"])
+
 # Umbrella target — includes everything via marisa.h.
 cc_library(
     name = "marisa-trie",
-    visibility = ["//visibility:public"],
     deps = [
         "//include:marisa",
         "//lib/marisa:trie",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,111 +1,61 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
+# Core public headers (header-only). Separated from the implementation to
+# break the circular dependency with //lib/marisa/grimoire:trie, which
+# includes marisa/agent.h and marisa/keyset.h.
 cc_library(
-    name = "public_headers",
+    name = "headers",
     hdrs = [
-        "include/marisa.h",
         "include/marisa/agent.h",
         "include/marisa/base.h",
-        "include/marisa/iostream.h",
         "include/marisa/key.h",
         "include/marisa/keyset.h",
         "include/marisa/query.h",
-        "include/marisa/stdio.h",
         "include/marisa/trie.h",
     ],
     strip_include_prefix = "include",
-)
-
-cc_library(
-    name = "internal_headers",
-    hdrs = [
-        "lib/marisa/grimoire/algorithm/sort.h",
-        "lib/marisa/grimoire/intrin.h",
-        "lib/marisa/grimoire/io.h",
-        "lib/marisa/grimoire/io/mapper.h",
-        "lib/marisa/grimoire/io/reader.h",
-        "lib/marisa/grimoire/io/writer.h",
-        "lib/marisa/grimoire/trie.h",
-        "lib/marisa/grimoire/trie/cache.h",
-        "lib/marisa/grimoire/trie/config.h",
-        "lib/marisa/grimoire/trie/entry.h",
-        "lib/marisa/grimoire/trie/header.h",
-        "lib/marisa/grimoire/trie/history.h",
-        "lib/marisa/grimoire/trie/key.h",
-        "lib/marisa/grimoire/trie/louds-trie.h",
-        "lib/marisa/grimoire/trie/range.h",
-        "lib/marisa/grimoire/trie/state.h",
-        "lib/marisa/grimoire/trie/tail.h",
-        "lib/marisa/grimoire/vector.h",
-        "lib/marisa/grimoire/vector/bit-vector.h",
-        "lib/marisa/grimoire/vector/flat-vector.h",
-        "lib/marisa/grimoire/vector/pop-count.h",
-        "lib/marisa/grimoire/vector/rank-index.h",
-        "lib/marisa/grimoire/vector/vector.h",
+    visibility = [
+        "//lib/marisa/grimoire:__pkg__",
+        "//tests:__pkg__",
     ],
-    strip_include_prefix = "lib",
 )
 
 cc_library(
-    name = "marisa-trie",
+    name = "stdio",
+    hdrs = ["include/marisa/stdio.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "iostream",
+    hdrs = ["include/marisa/iostream.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+# Core library implementation.
+cc_library(
+    name = "trie",
     srcs = [
         "lib/marisa/agent.cc",
-        "lib/marisa/grimoire/io/mapper.cc",
-        "lib/marisa/grimoire/io/reader.cc",
-        "lib/marisa/grimoire/io/writer.cc",
-        "lib/marisa/grimoire/trie/louds-trie.cc",
-        "lib/marisa/grimoire/trie/tail.cc",
-        "lib/marisa/grimoire/vector/bit-vector.cc",
         "lib/marisa/keyset.cc",
         "lib/marisa/trie.cc",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":internal_headers",
-        ":public_headers",
+        ":headers",
+        ":iostream",
+        ":stdio",
+        "//lib/marisa/grimoire:trie",
     ],
 )
 
+# Umbrella target — includes everything via marisa.h.
 cc_library(
-    name = "marisa-assert",
-    testonly = True,
-    hdrs = ["tests/marisa-assert.h"],
-    strip_include_prefix = "tests",
-)
-
-cc_test(
-    name = "base-test",
-    srcs = ["tests/base-test.cc"],
-    deps = [
-        ":marisa-assert",
-        ":marisa-trie",
-    ],
-)
-
-cc_test(
-    name = "io-test",
-    srcs = ["tests/io-test.cc"],
-    deps = [
-        ":marisa-assert",
-        ":marisa-trie",
-    ],
-)
-
-cc_test(
-    name = "marisa-test",
-    srcs = ["tests/marisa-test.cc"],
-    deps = [
-        ":marisa-assert",
-        ":marisa-trie",
-    ],
-)
-
-cc_test(
-    name = "trie-test",
-    srcs = ["tests/trie-test.cc"],
-    deps = [
-        ":marisa-assert",
-        ":marisa-trie",
-    ],
+    name = "marisa-trie",
+    hdrs = ["include/marisa.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [":trie"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,11 @@
-# Alias so external consumers can use @marisa-trie//:marisa-trie.
-alias(
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Umbrella target — includes everything via marisa.h.
+cc_library(
     name = "marisa-trie",
-    actual = "//include:marisa-trie",
     visibility = ["//visibility:public"],
+    deps = [
+        "//include:marisa",
+        "//lib/marisa:trie",
+    ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,9 +10,9 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//include:headers",
         "//include:iostream",
         "//include:stdio",
+        "//include:trie",
         "//lib/marisa/grimoire:trie",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,39 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-# Core public headers (header-only). Separated from the implementation to
-# break the circular dependency with //lib/marisa/grimoire:trie, which
-# includes marisa/agent.h and marisa/keyset.h.
-cc_library(
-    name = "headers",
-    hdrs = [
-        "include/marisa/agent.h",
-        "include/marisa/base.h",
-        "include/marisa/key.h",
-        "include/marisa/keyset.h",
-        "include/marisa/query.h",
-        "include/marisa/trie.h",
-    ],
-    strip_include_prefix = "include",
-    visibility = [
-        "//lib/marisa/grimoire:__pkg__",
-        "//tests:__pkg__",
-    ],
-)
-
-cc_library(
-    name = "stdio",
-    hdrs = ["include/marisa/stdio.h"],
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "iostream",
-    hdrs = ["include/marisa/iostream.h"],
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)
-
 # Core library implementation.
 cc_library(
     name = "trie",
@@ -44,18 +10,16 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":headers",
-        ":iostream",
-        ":stdio",
+        "//include:headers",
+        "//include:iostream",
+        "//include:stdio",
         "//lib/marisa/grimoire:trie",
     ],
 )
 
-# Umbrella target — includes everything via marisa.h.
-cc_library(
+# Alias so external consumers can use @marisa-trie//:marisa-trie.
+alias(
     name = "marisa-trie",
-    hdrs = ["include/marisa.h"],
-    strip_include_prefix = "include",
+    actual = "//include:marisa-trie",
     visibility = ["//visibility:public"],
-    deps = [":trie"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,22 +1,3 @@
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
-
-# Core library implementation.
-cc_library(
-    name = "trie",
-    srcs = [
-        "lib/marisa/agent.cc",
-        "lib/marisa/keyset.cc",
-        "lib/marisa/trie.cc",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//include:iostream",
-        "//include:stdio",
-        "//include:trie",
-        "//lib/marisa/grimoire:trie",
-    ],
-)
-
 # Alias so external consumers can use @marisa-trie//:marisa-trie.
 alias(
     name = "marisa-trie",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,111 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_library(
+    name = "public_headers",
+    hdrs = [
+        "include/marisa.h",
+        "include/marisa/agent.h",
+        "include/marisa/base.h",
+        "include/marisa/iostream.h",
+        "include/marisa/key.h",
+        "include/marisa/keyset.h",
+        "include/marisa/query.h",
+        "include/marisa/stdio.h",
+        "include/marisa/trie.h",
+    ],
+    strip_include_prefix = "include",
+)
+
+cc_library(
+    name = "internal_headers",
+    hdrs = [
+        "lib/marisa/grimoire/algorithm/sort.h",
+        "lib/marisa/grimoire/intrin.h",
+        "lib/marisa/grimoire/io.h",
+        "lib/marisa/grimoire/io/mapper.h",
+        "lib/marisa/grimoire/io/reader.h",
+        "lib/marisa/grimoire/io/writer.h",
+        "lib/marisa/grimoire/trie.h",
+        "lib/marisa/grimoire/trie/cache.h",
+        "lib/marisa/grimoire/trie/config.h",
+        "lib/marisa/grimoire/trie/entry.h",
+        "lib/marisa/grimoire/trie/header.h",
+        "lib/marisa/grimoire/trie/history.h",
+        "lib/marisa/grimoire/trie/key.h",
+        "lib/marisa/grimoire/trie/louds-trie.h",
+        "lib/marisa/grimoire/trie/range.h",
+        "lib/marisa/grimoire/trie/state.h",
+        "lib/marisa/grimoire/trie/tail.h",
+        "lib/marisa/grimoire/vector.h",
+        "lib/marisa/grimoire/vector/bit-vector.h",
+        "lib/marisa/grimoire/vector/flat-vector.h",
+        "lib/marisa/grimoire/vector/pop-count.h",
+        "lib/marisa/grimoire/vector/rank-index.h",
+        "lib/marisa/grimoire/vector/vector.h",
+    ],
+    strip_include_prefix = "lib",
+)
+
+cc_library(
+    name = "marisa-trie",
+    srcs = [
+        "lib/marisa/agent.cc",
+        "lib/marisa/grimoire/io/mapper.cc",
+        "lib/marisa/grimoire/io/reader.cc",
+        "lib/marisa/grimoire/io/writer.cc",
+        "lib/marisa/grimoire/trie/louds-trie.cc",
+        "lib/marisa/grimoire/trie/tail.cc",
+        "lib/marisa/grimoire/vector/bit-vector.cc",
+        "lib/marisa/keyset.cc",
+        "lib/marisa/trie.cc",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":internal_headers",
+        ":public_headers",
+    ],
+)
+
+cc_library(
+    name = "marisa-assert",
+    testonly = True,
+    hdrs = ["tests/marisa-assert.h"],
+    strip_include_prefix = "tests",
+)
+
+cc_test(
+    name = "base-test",
+    srcs = ["tests/base-test.cc"],
+    deps = [
+        ":marisa-assert",
+        ":marisa-trie",
+    ],
+)
+
+cc_test(
+    name = "io-test",
+    srcs = ["tests/io-test.cc"],
+    deps = [
+        ":marisa-assert",
+        ":marisa-trie",
+    ],
+)
+
+cc_test(
+    name = "marisa-test",
+    srcs = ["tests/marisa-test.cc"],
+    deps = [
+        ":marisa-assert",
+        ":marisa-trie",
+    ],
+)
+
+cc_test(
+    name = "trie-test",
+    srcs = ["tests/trie-test.cc"],
+    deps = [
+        ":marisa-assert",
+        ":marisa-trie",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,5 +6,4 @@ module(
     compatibility_level = 0,
 )
 
-bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,10 @@
+"""MARISA: Matching Algorithm with Recursively Implemented StorAge."""
+
+module(
+    name = "marisa-trie",
+    version = "0.3.1",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ To install just the binaries:
 $ sudo cmake --install build-rel --component Binaries
 ```
 
+#### Bazel
+
+Add the dependency to your `MODULE.bazel`:
+
+```starlark
+bazel_dep(name = "marisa-trie", version = "0.3.1")
+```
+
+Then depend on it in your `BUILD.bazel`:
+
+```starlark
+cc_binary(
+    name = "my_app",
+    srcs = ["main.cc"],
+    deps = ["@marisa-trie"],  # full library via marisa.h
+)
+```
+
+For finer-grained dependencies, you can depend on individual header targets
+in `@marisa-trie//include` (e.g. `@marisa-trie//include:trie`,
+`@marisa-trie//include:stdio`, `@marisa-trie//include:iostream`).
+
 #### Source code license
 
 Licensed under BSD-2-Clause OR LGPL-2.1-or-later.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ cc_binary(
 )
 ```
 
-For finer-grained dependencies, you can depend on individual header targets
-in `@marisa-trie//include` (e.g. `@marisa-trie//include:trie`,
-`@marisa-trie//include:stdio`, `@marisa-trie//include:iostream`).
-
 #### Source code license
 
 Licensed under BSD-2-Clause OR LGPL-2.1-or-later.

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -58,14 +58,12 @@ cc_library(
     name = "stdio",
     hdrs = ["marisa/stdio.h"],
     strip_include_prefix = "/include",
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "iostream",
     hdrs = ["marisa/iostream.h"],
     strip_include_prefix = "/include",
-    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Core public headers (header-only). Separated from the implementation to
+# break the circular dependency with //lib/marisa/grimoire:trie, which
+# includes marisa/agent.h and marisa/keyset.h.
+cc_library(
+    name = "headers",
+    hdrs = [
+        "marisa/agent.h",
+        "marisa/base.h",
+        "marisa/key.h",
+        "marisa/keyset.h",
+        "marisa/query.h",
+        "marisa/trie.h",
+    ],
+    strip_include_prefix = "/include",
+    visibility = [
+        "//:__pkg__",
+        "//lib/marisa/grimoire:__pkg__",
+        "//tests:__pkg__",
+    ],
+)
+
+cc_library(
+    name = "stdio",
+    hdrs = ["marisa/stdio.h"],
+    strip_include_prefix = "/include",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "iostream",
+    hdrs = ["marisa/iostream.h"],
+    strip_include_prefix = "/include",
+    visibility = ["//visibility:public"],
+)
+
+# Umbrella target — includes everything via marisa.h.
+cc_library(
+    name = "marisa-trie",
+    hdrs = ["marisa.h"],
+    strip_include_prefix = "/include",
+    visibility = ["//visibility:public"],
+    deps = ["//:trie"],
+)

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -73,11 +73,9 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-# Umbrella target — includes everything via marisa.h.
 cc_library(
-    name = "marisa-trie",
+    name = "marisa",
     hdrs = ["marisa.h"],
     strip_include_prefix = "/include",
-    visibility = ["//visibility:public"],
-    deps = ["//lib/marisa:trie"],
+    visibility = ["//:__pkg__"],
 )

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -1,23 +1,22 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-_INTERNAL_VISIBILITY = [
+package(default_visibility = [
+    "//:__pkg__",
     "//lib/marisa:__pkg__",
     "//lib/marisa/grimoire:__pkg__",
     "//tests:__pkg__",
-]
+])
 
 cc_library(
     name = "base",
     hdrs = ["marisa/base.h"],
     strip_include_prefix = "/include",
-    visibility = _INTERNAL_VISIBILITY,
 )
 
 cc_library(
     name = "key",
     hdrs = ["marisa/key.h"],
     strip_include_prefix = "/include",
-    visibility = _INTERNAL_VISIBILITY,
     deps = [":base"],
 )
 
@@ -25,7 +24,6 @@ cc_library(
     name = "query",
     hdrs = ["marisa/query.h"],
     strip_include_prefix = "/include",
-    visibility = _INTERNAL_VISIBILITY,
     deps = [":base"],
 )
 
@@ -33,7 +31,6 @@ cc_library(
     name = "keyset",
     hdrs = ["marisa/keyset.h"],
     strip_include_prefix = "/include",
-    visibility = _INTERNAL_VISIBILITY,
     deps = [":key"],
 )
 
@@ -41,7 +38,6 @@ cc_library(
     name = "agent",
     hdrs = ["marisa/agent.h"],
     strip_include_prefix = "/include",
-    visibility = _INTERNAL_VISIBILITY,
     deps = [
         ":key",
         ":query",
@@ -52,7 +48,6 @@ cc_library(
     name = "trie",
     hdrs = ["marisa/trie.h"],
     strip_include_prefix = "/include",
-    visibility = _INTERNAL_VISIBILITY,
     deps = [
         ":agent",
         ":keyset",
@@ -77,5 +72,4 @@ cc_library(
     name = "marisa",
     hdrs = ["marisa.h"],
     strip_include_prefix = "/include",
-    visibility = ["//:__pkg__"],
 )

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -1,23 +1,61 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-# Core public headers (header-only). Separated from the implementation to
-# break the circular dependency with //lib/marisa/grimoire:trie, which
-# includes marisa/agent.h and marisa/keyset.h.
+_INTERNAL_VISIBILITY = [
+    "//:__pkg__",
+    "//lib/marisa/grimoire:__pkg__",
+    "//tests:__pkg__",
+]
+
 cc_library(
-    name = "headers",
-    hdrs = [
-        "marisa/agent.h",
-        "marisa/base.h",
-        "marisa/key.h",
-        "marisa/keyset.h",
-        "marisa/query.h",
-        "marisa/trie.h",
-    ],
+    name = "base",
+    hdrs = ["marisa/base.h"],
     strip_include_prefix = "/include",
-    visibility = [
-        "//:__pkg__",
-        "//lib/marisa/grimoire:__pkg__",
-        "//tests:__pkg__",
+    visibility = _INTERNAL_VISIBILITY,
+)
+
+cc_library(
+    name = "key",
+    hdrs = ["marisa/key.h"],
+    strip_include_prefix = "/include",
+    visibility = _INTERNAL_VISIBILITY,
+    deps = [":base"],
+)
+
+cc_library(
+    name = "query",
+    hdrs = ["marisa/query.h"],
+    strip_include_prefix = "/include",
+    visibility = _INTERNAL_VISIBILITY,
+    deps = [":base"],
+)
+
+cc_library(
+    name = "keyset",
+    hdrs = ["marisa/keyset.h"],
+    strip_include_prefix = "/include",
+    visibility = _INTERNAL_VISIBILITY,
+    deps = [":key"],
+)
+
+cc_library(
+    name = "agent",
+    hdrs = ["marisa/agent.h"],
+    strip_include_prefix = "/include",
+    visibility = _INTERNAL_VISIBILITY,
+    deps = [
+        ":key",
+        ":query",
+    ],
+)
+
+cc_library(
+    name = "trie",
+    hdrs = ["marisa/trie.h"],
+    strip_include_prefix = "/include",
+    visibility = _INTERNAL_VISIBILITY,
+    deps = [
+        ":agent",
+        ":keyset",
     ],
 )
 

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 _INTERNAL_VISIBILITY = [
-    "//:__pkg__",
+    "//lib/marisa:__pkg__",
     "//lib/marisa/grimoire:__pkg__",
     "//tests:__pkg__",
 ]
@@ -79,5 +79,5 @@ cc_library(
     hdrs = ["marisa.h"],
     strip_include_prefix = "/include",
     visibility = ["//visibility:public"],
-    deps = ["//:trie"],
+    deps = ["//lib/marisa:trie"],
 )

--- a/lib/marisa/BUILD.bazel
+++ b/lib/marisa/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Core library implementation.
+cc_library(
+    name = "trie",
+    srcs = [
+        "agent.cc",
+        "keyset.cc",
+        "trie.cc",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//include:iostream",
+        "//include:stdio",
+        "//include:trie",
+        "//lib/marisa/grimoire:trie",
+    ],
+)

--- a/lib/marisa/BUILD.bazel
+++ b/lib/marisa/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//:__pkg__"])
 
 # Core library implementation.
 cc_library(

--- a/lib/marisa/BUILD.bazel
+++ b/lib/marisa/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+package(default_visibility = ["//visibility:public"])
+
 # Core library implementation.
 cc_library(
     name = "trie",
@@ -8,7 +10,6 @@ cc_library(
         "keyset.cc",
         "trie.cc",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//include:iostream",
         "//include:stdio",

--- a/lib/marisa/grimoire/BUILD.bazel
+++ b/lib/marisa/grimoire/BUILD.bazel
@@ -1,0 +1,72 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = [
+    "//:__pkg__",
+    "//tests:__pkg__",
+])
+
+cc_library(
+    name = "io",
+    srcs = [
+        "io/mapper.cc",
+        "io/reader.cc",
+        "io/writer.cc",
+    ],
+    hdrs = [
+        "io.h",
+        "io/mapper.h",
+        "io/reader.h",
+        "io/writer.h",
+    ],
+    strip_include_prefix = "/lib",
+    deps = ["//:headers"],
+)
+
+cc_library(
+    name = "vector",
+    srcs = ["vector/bit-vector.cc"],
+    hdrs = [
+        "intrin.h",
+        "vector.h",
+        "vector/bit-vector.h",
+        "vector/flat-vector.h",
+        "vector/pop-count.h",
+        "vector/rank-index.h",
+        "vector/vector.h",
+    ],
+    strip_include_prefix = "/lib",
+    deps = [":io"],
+)
+
+cc_library(
+    name = "algorithm",
+    hdrs = ["algorithm/sort.h"],
+    strip_include_prefix = "/lib",
+)
+
+cc_library(
+    name = "trie",
+    srcs = [
+        "trie/louds-trie.cc",
+        "trie/tail.cc",
+    ],
+    hdrs = [
+        "trie.h",
+        "trie/cache.h",
+        "trie/config.h",
+        "trie/entry.h",
+        "trie/header.h",
+        "trie/history.h",
+        "trie/key.h",
+        "trie/louds-trie.h",
+        "trie/range.h",
+        "trie/state.h",
+        "trie/tail.h",
+    ],
+    strip_include_prefix = "/lib",
+    deps = [
+        ":algorithm",
+        ":vector",
+        "//:headers",
+    ],
+)

--- a/lib/marisa/grimoire/BUILD.bazel
+++ b/lib/marisa/grimoire/BUILD.bazel
@@ -19,7 +19,7 @@ cc_library(
         "io/writer.h",
     ],
     strip_include_prefix = "/lib",
-    deps = ["//include:headers"],
+    deps = ["//include:base"],
 )
 
 cc_library(
@@ -67,6 +67,7 @@ cc_library(
     deps = [
         ":algorithm",
         ":vector",
-        "//include:headers",
+        "//include:agent",
+        "//include:keyset",
     ],
 )

--- a/lib/marisa/grimoire/BUILD.bazel
+++ b/lib/marisa/grimoire/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = [
-    "//:__pkg__",
+    "//lib/marisa:__pkg__",
     "//tests:__pkg__",
 ])
 

--- a/lib/marisa/grimoire/BUILD.bazel
+++ b/lib/marisa/grimoire/BUILD.bazel
@@ -19,7 +19,7 @@ cc_library(
         "io/writer.h",
     ],
     strip_include_prefix = "/lib",
-    deps = ["//:headers"],
+    deps = ["//include:headers"],
 )
 
 cc_library(
@@ -67,6 +67,6 @@ cc_library(
     deps = [
         ":algorithm",
         ":vector",
-        "//:headers",
+        "//include:headers",
     ],
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_library(
+    name = "marisa-assert",
+    testonly = True,
+    hdrs = ["marisa-assert.h"],
+    strip_include_prefix = "/tests",
+)
+
+cc_test(
+    name = "base-test",
+    srcs = ["base-test.cc"],
+    deps = [
+        ":marisa-assert",
+        "//:marisa-trie",
+    ],
+)
+
+cc_test(
+    name = "io-test",
+    srcs = ["io-test.cc"],
+    deps = [
+        ":marisa-assert",
+        "//lib/marisa/grimoire:io",
+    ],
+)
+
+cc_test(
+    name = "vector-test",
+    srcs = ["vector-test.cc"],
+    deps = [
+        ":marisa-assert",
+        "//lib/marisa/grimoire:vector",
+    ],
+)
+
+cc_test(
+    name = "trie-test",
+    srcs = ["trie-test.cc"],
+    deps = [
+        ":marisa-assert",
+        "//lib/marisa/grimoire:trie",
+    ],
+)
+
+cc_test(
+    name = "marisa-test",
+    srcs = ["marisa-test.cc"],
+    deps = [
+        ":marisa-assert",
+        "//:marisa-trie",
+    ],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
+package(default_visibility = ["//visibility:private"])
+
 cc_library(
     name = "marisa-assert",
     testonly = True,


### PR DESCRIPTION
## Summary

- Add `MODULE.bazel`, `BUILD.bazel`, and `.bazelrc` to enable building with Bazel (bzlmod)
- C++17 standard is configured via `.bazelrc` using platform-specific configs and `-D_WIN32_WINNT=_WIN32_WINNT_WIN8`
- Defines the main `:marisa-trie` library target and 4 test targets (`base-test`, `io-test`, `marisa-test`, `trie-test`)

## Test plan

- [x] `bazel build //:marisa-trie` builds successfully on Linux/macOS/Windows
- [x] `bazel test //...` passes all 4 test targets
- Github workflow