### PR TITLE
Add support for building and testing marisa-trie on Windows ARM64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,11 +20,17 @@ concurrency:
 jobs:
   cmake:
     name: CMake - MSVC ${{ matrix.platform }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
-        platform: [x64, Win32]
+        include:
+          - platform: x64
+            runner: windows-latest
+          - platform: win32
+            runner: windows-latest
+          - platform: ARM64
+            runner: windows-11-arm
 
     steps:
       - name: Checkout

--- a/lib/marisa/grimoire/intrin.h
+++ b/lib/marisa/grimoire/intrin.h
@@ -135,7 +135,7 @@
  #endif  // MARISA_WORD_SIZE == 64
 #endif   // _MSC_VER
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(_M_ARM64)
  #define MARISA_AARCH64
  #include <arm_neon.h>
 #endif


### PR DESCRIPTION
PR Description:
- The PR adds CI support for building and testing marisa-trie on Windows ARM64.

Changes proposed:
- Added Windows ARM64 build configurations in the workflow file[ [windows.yml](https://github.com/s-yata/marisa-trie/compare/master...MugundanMCW:marisa-trie:master#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773c) ]