### PR TITLE
Fix UB in FlatVector::build_() by storing to units_ directly

### DIFF
--- a/lib/marisa/grimoire/vector/flat-vector.h
+++ b/lib/marisa/grimoire/vector/flat-vector.h
@@ -118,9 +118,6 @@ class FlatVector {
     }
 
     units_.resize(num_units);
-    if (num_units > 0) {
-      units_.back() = 0;
-    }
 
     value_size_ = value_size;
     if (value_size != 0) {
@@ -128,8 +125,31 @@ class FlatVector {
     }
     size_ = values.size();
 
+    // Pack values into units_ by accumulating bits and storing each
+    // completed unit, without reading from units_.
+    Unit unit = 0;
+    std::size_t unit_id = 0;
+    std::size_t unit_offset = 0;
     for (std::size_t i = 0; i < values.size(); ++i) {
-      set(i, values[i]);
+      const Unit value{values[i]};
+      assert(value <= mask_);
+      unit |= value << unit_offset;
+      unit_offset += value_size;
+      if (unit_offset >= MARISA_WORD_SIZE) {
+        units_[unit_id++] = unit;
+        unit_offset -= MARISA_WORD_SIZE;
+        unit = unit_offset != 0 ? value >> (value_size - unit_offset) : 0;
+      }
+    }
+    // At most one partial unit remains: the loop stores a unit every time
+    // unit_offset crosses MARISA_WORD_SIZE, so only the last incomplete
+    // unit is left.
+    if (unit_id < num_units) {
+      units_[unit_id++] = unit;
+    }
+    // Zero any trailing units produced by alignment rounding.
+    while (unit_id < num_units) {
+      units_[unit_id++] = 0;
     }
   }
 
@@ -180,24 +200,6 @@ class FlatVector {
     writer.write(static_cast<uint32_t>(value_size_));
     writer.write(static_cast<uint32_t>(mask_));
     writer.write(static_cast<uint64_t>(size_));
-  }
-
-  void set(std::size_t i, uint32_t value) {
-    assert(i < size_);
-    assert(value <= mask_);
-
-    const std::size_t pos = i * value_size_;
-    const std::size_t unit_id = pos / MARISA_WORD_SIZE;
-    const std::size_t unit_offset = pos % MARISA_WORD_SIZE;
-
-    units_[unit_id] &= ~(static_cast<Unit>(mask_) << unit_offset);
-    units_[unit_id] |= static_cast<Unit>(value & mask_) << unit_offset;
-    if ((unit_offset + value_size_) > MARISA_WORD_SIZE) {
-      units_[unit_id + 1] &=
-          ~(static_cast<Unit>(mask_) >> (MARISA_WORD_SIZE - unit_offset));
-      units_[unit_id + 1] |=
-          static_cast<Unit>(value & mask_) >> (MARISA_WORD_SIZE - unit_offset);
-    }
   }
 };
 

--- a/tests/vector-test.cc
+++ b/tests/vector-test.cc
@@ -304,6 +304,77 @@ void TestFlatVector() {
   TEST_END();
 }
 
+void TestFlatVectorUninitializedBuild() {
+  // Regression test for UB in the old set()-based build_() loop.
+  //
+  // The old code called units_.resize(num_units) (default-init, leaving
+  // units indeterminate), then only zeroed units_.back(). set() performed
+  // a read-modify-write (units_[id] &= ~(mask << offset)) on uninitialized
+  // units, which was UB.
+  //
+  // This configuration (value_size_=3, 30 values, 90 bits) allocates
+  // multiple units, exercising the bit-packing loop across unit boundaries.
+  TEST_START();
+
+  marisa::grimoire::Vector<std::uint32_t> values;
+  values.reserve(30);
+  values.push_back(7);
+  for (std::size_t i = 1; i < 30; ++i) {
+    values.push_back(static_cast<std::uint32_t>(random_engine() % 8));
+  }
+  marisa::grimoire::FlatVector vec;
+  vec.build(values);
+  for (std::size_t i = 0; i < vec.size(); ++i) {
+    ASSERT(vec[i] == values[i]);
+  }
+
+  TEST_END();
+}
+
+void TestFlatVectorUninitializedBuildSerialize() {
+  // Regression test: serializes a FlatVector and checks that the unit data
+  // bytes are all zero.
+  //
+  // The old build_() code only zeroed units_.back(). With value_size_==0,
+  // num_units is 64/MARISA_WORD_SIZE (1 on 64-bit, 2 on 32-bit). On 32-bit,
+  // units_[0] was never initialized and contained garbage that would appear
+  // in the serialized output.
+  //
+  // See:
+  // https://github.com/BYVoid/OpenCC/commit/c3e07074e282b80083ed7734be51caecf9e7804f
+  TEST_START();
+
+  marisa::grimoire::Vector<std::uint32_t> values;
+  values.push_back(0);
+  marisa::grimoire::FlatVector vec;
+  vec.build(values);
+
+  ASSERT(vec.value_size() == 0);
+  ASSERT(vec.size() == 1);
+  ASSERT(vec[0] == 0);
+
+  std::stringstream stream;
+  {
+    marisa::grimoire::Writer writer;
+    writer.open(stream);
+    vec.write(writer);
+  }
+  const std::string data = stream.str();
+  // FlatVector serialization format (32 bytes total):
+  //   [0,  8)  Vector::write_ uint64_t size header (= 8, the unit data size)
+  //   [8,  16) unit data (8 bytes on both 32-bit and 64-bit)
+  //   [16, 20) value_size_ as uint32_t
+  //   [20, 24) mask_ as uint32_t
+  //   [24, 32) size_ as uint64_t
+  ASSERT(data.size() == 32);
+  // Check that bytes [8, 16) — the unit data — are all zero.
+  for (std::size_t i = 8; i < 16; ++i) {
+    ASSERT(data[i] == '\0');
+  }
+
+  TEST_END();
+}
+
 void TestBitVector(std::size_t size) {
   marisa::grimoire::BitVector bv;
 
@@ -406,6 +477,8 @@ int main() try {
 
   TestVector();
   TestFlatVector();
+  TestFlatVectorUninitializedBuild();
+  TestFlatVectorUninitializedBuildSerialize();
   TestBitVector();
 
   return 0;


### PR DESCRIPTION
The old build_() loop called set(), which performed read-modify-write operations on default-initialized (indeterminate) units_. This was UB because units_.resize(num_units) leaves values uninitialized, and only units_.back() was zeroed.

Replace the set() loop with a forward bit-packing loop that accumulates bits into a local variable and stores each completed unit directly, never reading from units_. Remove the now-unused set() method.

Add regression tests exercising multi-unit bit packing and serialization of zero-valued FlatVectors.