### PR TITLE
Use standard library functions instead of manual loops

### DIFF
--- a/lib/marisa/grimoire/io/reader.cc
+++ b/lib/marisa/grimoire/io/reader.cc
@@ -4,6 +4,7 @@
  #include <unistd.h>
 #endif  // _WIN32
 
+#include <algorithm>
 #include <cerrno>
 #include <limits>
 #include <stdexcept>
@@ -72,7 +73,7 @@ void Reader::seek(std::size_t size) {
   } else {
     char buf[1024];
     while (size != 0) {
-      const std::size_t count = (size < sizeof(buf)) ? size : sizeof(buf);
+      const std::size_t count = std::min(size, sizeof(buf));
       read_data(buf, count);
       size -= count;
     }
@@ -119,13 +120,14 @@ void Reader::read_data(void *buf, std::size_t size) {
     while (size != 0) {
 #ifdef _WIN32
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits<int>::max();
-      const unsigned int count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
+      const unsigned int count =
+          static_cast<unsigned int>(std::min(size, CHUNK_SIZE));
       const int size_read = ::_read(fd_, buf, count);
       MARISA_THROW_SYSTEM_ERROR_IF(size_read <= 0, errno,
                                    std::generic_category(), "_read");
 #else   // _WIN32
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits< ::ssize_t>::max();
-      const ::size_t count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
+      const ::size_t count = std::min(size, CHUNK_SIZE);
       const ::ssize_t size_read = ::read(fd_, buf, count);
       MARISA_THROW_SYSTEM_ERROR_IF(size_read <= 0, errno,
                                    std::generic_category(), "read");

--- a/lib/marisa/grimoire/io/writer.cc
+++ b/lib/marisa/grimoire/io/writer.cc
@@ -4,6 +4,7 @@
  #include <unistd.h>
 #endif  // _WIN32
 
+#include <algorithm>
 #include <cerrno>
 #include <limits>
 #include <stdexcept>
@@ -72,7 +73,7 @@ void Writer::seek(std::size_t size) {
   } else {
     const char buf[1024] = {};
     do {
-      const std::size_t count = (size < sizeof(buf)) ? size : sizeof(buf);
+      const std::size_t count = std::min(size, sizeof(buf));
       write_data(buf, count);
       size -= count;
     } while (size != 0);
@@ -119,13 +120,14 @@ void Writer::write_data(const void *data, std::size_t size) {
     while (size != 0) {
 #ifdef _WIN32
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits<int>::max();
-      const unsigned int count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
+      const unsigned int count =
+          static_cast<unsigned int>(std::min(size, CHUNK_SIZE));
       const int size_written = ::_write(fd_, data, count);
       MARISA_THROW_SYSTEM_ERROR_IF(size_written <= 0, errno,
                                    std::generic_category(), "_write");
 #else   // _WIN32
       constexpr std::size_t CHUNK_SIZE = std::numeric_limits< ::ssize_t>::max();
-      const ::size_t count = (size < CHUNK_SIZE) ? size : CHUNK_SIZE;
+      const ::size_t count = std::min(size, CHUNK_SIZE);
       const ::ssize_t size_written = ::write(fd_, data, count);
       MARISA_THROW_SYSTEM_ERROR_IF(size_written <= 0, errno,
                                    std::generic_category(), "write");

--- a/lib/marisa/grimoire/trie/header.h
+++ b/lib/marisa/grimoire/trie/header.h
@@ -1,6 +1,7 @@
 #ifndef MARISA_GRIMOIRE_TRIE_HEADER_H_
 #define MARISA_GRIMOIRE_TRIE_HEADER_H_
 
+#include <cstring>
 #include <stdexcept>
 
 #include "marisa/grimoire/io.h"
@@ -43,12 +44,7 @@ class Header {
   }
 
   static bool test_header(const char *ptr) {
-    for (std::size_t i = 0; i < HEADER_SIZE; ++i) {
-      if (ptr[i] != get_header()[i]) {
-        return false;
-      }
-    }
-    return true;
+    return std::memcmp(ptr, get_header(), HEADER_SIZE) == 0;
   }
 };
 

--- a/lib/marisa/grimoire/trie/key.h
+++ b/lib/marisa/grimoire/trie/key.h
@@ -2,6 +2,7 @@
 #define MARISA_GRIMOIRE_TRIE_KEY_H_
 
 #include <cassert>
+#include <string_view>
 
 #include "marisa/base.h"
 
@@ -71,15 +72,8 @@ class Key {
 };
 
 inline bool operator==(const Key &lhs, const Key &rhs) {
-  if (lhs.length() != rhs.length()) {
-    return false;
-  }
-  for (std::size_t i = 0; i < lhs.length(); ++i) {
-    if (lhs[i] != rhs[i]) {
-      return false;
-    }
-  }
-  return true;
+  return std::string_view(lhs.ptr(), lhs.length()) ==
+         std::string_view(rhs.ptr(), rhs.length());
 }
 
 inline bool operator!=(const Key &lhs, const Key &rhs) {
@@ -166,15 +160,8 @@ class ReverseKey {
 };
 
 inline bool operator==(const ReverseKey &lhs, const ReverseKey &rhs) {
-  if (lhs.length() != rhs.length()) {
-    return false;
-  }
-  for (std::size_t i = 0; i < lhs.length(); ++i) {
-    if (lhs[i] != rhs[i]) {
-      return false;
-    }
-  }
-  return true;
+  return std::string_view(lhs.ptr(), lhs.length()) ==
+         std::string_view(rhs.ptr(), rhs.length());
 }
 
 inline bool operator!=(const ReverseKey &lhs, const ReverseKey &rhs) {

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -1,6 +1,9 @@
 #include "marisa/grimoire/trie/louds-trie.h"
 
 #include <algorithm>
+#if __cplusplus >= 202002L
+ #include <bit>
+#endif
 #include <cassert>
 #include <functional>
 #include <queue>
@@ -492,10 +495,17 @@ void LoudsTrie::cache<Key>(std::size_t parent, std::size_t child, float weight,
 
 void LoudsTrie::reserve_cache(const Config &config, std::size_t trie_id,
                               std::size_t num_keys) {
-  std::size_t cache_size = (trie_id == 1) ? 256 : 1;
-  while (cache_size < (num_keys / config.cache_level())) {
+  const std::size_t min_cache_size = (trie_id == 1) ? 256 : 1;
+  const std::size_t target = num_keys / config.cache_level();
+#if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 202002L
+  const std::size_t cache_size =
+      std::max(min_cache_size, std::bit_ceil(target));
+#else
+  std::size_t cache_size = min_cache_size;
+  while (cache_size < target) {
     cache_size *= 2;
   }
+#endif
   cache_.resize(cache_size);
   cache_mask_ = cache_size - 1;
 }

--- a/lib/marisa/grimoire/vector/flat-vector.h
+++ b/lib/marisa/grimoire/vector/flat-vector.h
@@ -1,6 +1,10 @@
 #ifndef MARISA_GRIMOIRE_VECTOR_FLAT_VECTOR_H_
 #define MARISA_GRIMOIRE_VECTOR_FLAT_VECTOR_H_
 
+#include <algorithm>
+#if __cplusplus >= 202002L
+ #include <bit>
+#endif
 #include <cassert>
 #include <stdexcept>
 
@@ -95,18 +99,18 @@ class FlatVector {
   std::size_t size_ = 0;
 
   void build_(const Vector<uint32_t> &values) {
-    uint32_t max_value = 0;
-    for (std::size_t i = 0; i < values.size(); ++i) {
-      if (values[i] > max_value) {
-        max_value = values[i];
-      }
-    }
+    uint32_t max_value =
+        values.empty() ? 0 : *std::max_element(values.begin(), values.end());
 
+#if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 202002L
+    const std::size_t value_size = std::bit_width(max_value);
+#else
     std::size_t value_size = 0;
     while (max_value != 0) {
       ++value_size;
       max_value >>= 1;
     }
+#endif
 
     std::size_t num_units = values.empty() ? 0 : (64 / MARISA_WORD_SIZE);
     if (value_size != 0) {


### PR DESCRIPTION
Replace manual max loop with std::max_element (flat-vector.h), manual byte comparisons with std::string_view and std::memcmp (key.h, header.h), and manual min ternaries with std::min (reader.cc, writer.cc).

Add C++20 std::bit_width (flat-vector.h) and std::bit_ceil (louds-trie.cc) behind __cpp_lib_int_pow2 feature test guards, with manual fallbacks for pre-C++20 compilers.