### PR TITLE
Narrow internal getter return types from size_t to uint32_t

### DIFF
--- a/lib/marisa/grimoire/trie/cache.h
+++ b/lib/marisa/grimoire/trie/cache.h
@@ -33,22 +33,22 @@ class Cache {
     union_.weight = weight;
   }
 
-  std::size_t parent() const {
+  uint32_t parent() const {
     return parent_;
   }
-  std::size_t child() const {
+  uint32_t child() const {
     return child_;
   }
   uint8_t base() const {
     return static_cast<uint8_t>(union_.link & 0xFFU);
   }
-  std::size_t extra() const {
+  uint32_t extra() const {
     return union_.link >> 8;
   }
   char label() const {
     return static_cast<char>(base());
   }
-  std::size_t link() const {
+  uint32_t link() const {
     return union_.link;
   }
   float weight() const {

--- a/lib/marisa/grimoire/trie/entry.h
+++ b/lib/marisa/grimoire/trie/entry.h
@@ -32,10 +32,10 @@ class Entry {
   const char *ptr() const {
     return ptr_ - length_ + 1;
   }
-  std::size_t length() const {
+  uint32_t length() const {
     return length_;
   }
-  std::size_t id() const {
+  uint32_t id() const {
     return id_;
   }
 

--- a/lib/marisa/grimoire/trie/history.h
+++ b/lib/marisa/grimoire/trie/history.h
@@ -32,19 +32,19 @@ class History {
     key_id_ = static_cast<uint32_t>(key_id);
   }
 
-  std::size_t node_id() const {
+  uint32_t node_id() const {
     return node_id_;
   }
-  std::size_t louds_pos() const {
+  uint32_t louds_pos() const {
     return louds_pos_;
   }
-  std::size_t key_pos() const {
+  uint32_t key_pos() const {
     return key_pos_;
   }
-  std::size_t link_id() const {
+  uint32_t link_id() const {
     return link_id_;
   }
-  std::size_t key_id() const {
+  uint32_t key_id() const {
     return key_id_;
   }
 

--- a/lib/marisa/grimoire/trie/key.h
+++ b/lib/marisa/grimoire/trie/key.h
@@ -47,16 +47,16 @@ class Key {
   const char *ptr() const {
     return ptr_;
   }
-  std::size_t length() const {
+  uint32_t length() const {
     return length_;
   }
   float weight() const {
     return union_.weight;
   }
-  std::size_t terminal() const {
+  uint32_t terminal() const {
     return union_.terminal;
   }
-  std::size_t id() const {
+  uint32_t id() const {
     return id_;
   }
 
@@ -142,16 +142,16 @@ class ReverseKey {
   const char *ptr() const {
     return ptr_ - length_;
   }
-  std::size_t length() const {
+  uint32_t length() const {
     return length_;
   }
   float weight() const {
     return union_.weight;
   }
-  std::size_t terminal() const {
+  uint32_t terminal() const {
     return union_.terminal;
   }
-  std::size_t id() const {
+  uint32_t id() const {
     return id_;
   }
 

--- a/lib/marisa/grimoire/trie/louds-trie.cc
+++ b/lib/marisa/grimoire/trie/louds-trie.cc
@@ -472,7 +472,7 @@ void LoudsTrie::build_terminals(const Vector<T> &keys,
   Vector<uint32_t> temp;
   temp.resize(keys.size());
   for (std::size_t i = 0; i < keys.size(); ++i) {
-    temp[keys[i].id()] = static_cast<uint32_t>(keys[i].terminal());
+    temp[keys[i].id()] = keys[i].terminal();
   }
   terminals->swap(temp);
 }

--- a/lib/marisa/grimoire/trie/range.h
+++ b/lib/marisa/grimoire/trie/range.h
@@ -24,13 +24,13 @@ class Range {
     key_pos_ = static_cast<uint32_t>(key_pos);
   }
 
-  std::size_t begin() const {
+  uint32_t begin() const {
     return begin_;
   }
-  std::size_t end() const {
+  uint32_t end() const {
     return end_;
   }
-  std::size_t key_pos() const {
+  uint32_t key_pos() const {
     return key_pos_;
   }
 
@@ -72,13 +72,13 @@ class WeightedRange {
   const Range &range() const {
     return range_;
   }
-  std::size_t begin() const {
+  uint32_t begin() const {
     return range_.begin();
   }
-  std::size_t end() const {
+  uint32_t end() const {
     return range_.end();
   }
-  std::size_t key_pos() const {
+  uint32_t key_pos() const {
     return range_.key_pos();
   }
   float weight() const {

--- a/lib/marisa/grimoire/trie/state.h
+++ b/lib/marisa/grimoire/trie/state.h
@@ -43,13 +43,13 @@ class State {
     status_code_ = status_code;
   }
 
-  std::size_t node_id() const {
+  uint32_t node_id() const {
     return node_id_;
   }
-  std::size_t query_pos() const {
+  uint32_t query_pos() const {
     return query_pos_;
   }
-  std::size_t history_pos() const {
+  uint32_t history_pos() const {
     return history_pos_;
   }
   StatusCode status_code() const {

--- a/lib/marisa/grimoire/vector/rank-index.h
+++ b/lib/marisa/grimoire/vector/rank-index.h
@@ -49,28 +49,28 @@ class RankIndex {
                                     ((value & 0x1FFU) << 18));
   }
 
-  std::size_t abs() const {
+  uint32_t abs() const {
     return abs_;
   }
-  std::size_t rel1() const {
+  uint32_t rel1() const {
     return rel_lo_ & 0x7FU;
   }
-  std::size_t rel2() const {
+  uint32_t rel2() const {
     return (rel_lo_ >> 7) & 0xFFU;
   }
-  std::size_t rel3() const {
+  uint32_t rel3() const {
     return (rel_lo_ >> 15) & 0xFFU;
   }
-  std::size_t rel4() const {
+  uint32_t rel4() const {
     return (rel_lo_ >> 23) & 0x1FFU;
   }
-  std::size_t rel5() const {
+  uint32_t rel5() const {
     return rel_hi_ & 0x1FFU;
   }
-  std::size_t rel6() const {
+  uint32_t rel6() const {
     return (rel_hi_ >> 9) & 0x1FFU;
   }
-  std::size_t rel7() const {
+  uint32_t rel7() const {
     return (rel_hi_ >> 18) & 0x1FFU;
   }
 


### PR DESCRIPTION
These functions all return values stored in uint32_t (or narrower) members. Returning size_t on 64-bit platforms widens unnecessarily. No functional change; all call sites use the values in contexts where uint32_t implicitly widens to size_t.

The public Key functions can optionally be changed separately.